### PR TITLE
fix(component): Fix card description heigth

### DIFF
--- a/src/components/Collection.vue
+++ b/src/components/Collection.vue
@@ -303,6 +303,7 @@ export default {
 
       .header {
         width: 100%;
+        height: 100%;
       }
 
       .fixed-options {


### PR DESCRIPTION
Fix card height when two or more cards in a carousel has different number of lines in the description.