### PR TITLE
Remove memory leaks in scroll, audio and video

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -428,11 +428,7 @@ export default {
     },
     onUnsupportedType: function(document) {},
     toogleBlipGroupCard: function() {
-      if (this.showBlipGroupCard) {
-        this.showBlipGroupCard = false
-      } else {
-        this.showBlipGroupCard = true
-      }
+      this.showBlipGroupCard = !this.showBlipGroupCard
     }
   },
   data: function() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -59,6 +59,7 @@
         <button class="button" @click="sendChatState">ENVIAR Chatstate</button>
         <button class="button" @click="sendTicket">ENVIAR Ticket</button>
         <button class="button" @click="sendRaw">ENVIAR Unsuportend Content</button>
+        <button class="button" @click="toogleBlipGroupCard">CRIAR/DESTRUIR scroll</button>
       </div>
 
       <div v-else>
@@ -68,7 +69,7 @@
       </div>
     </div>
 
-    <div :style="'float: left; width:' + width + 'px; margin: 50px 100px; background-color: #FAF9F8; height: 800px;'" v-chat-scroll="{scrollToTop: false}">
+    <div v-if="showBlipGroupCard" :style="'float: left; width:' + width + 'px; margin: 50px 100px; background-color: #FAF9F8; height: 800px;'" v-chat-scroll="{scrollToTop: false}">
       <div style="padding: 20px">
         <blip-group-card v-if="group" :documents="docs" :photo="photoUri" :deletable="true" :on-selected="selected" :hide-options="false" :on-save="save" :on-deleted="deleted" :editable="true" :on-open-link="selected" :on-unsupported-type="onUnsupportedType" :on-location-error="selected"/>
         <div v-else v-for="(item, index) in docs" v-bind:key="index">
@@ -301,7 +302,7 @@ export default {
         type: 'application/vnd.lime.media-link+json',
         content: {
           type: 'audio/mp3',
-          uri: 'http://blaamandagjazzband.dk/jazz/mp3/basin_street_blues.mp3',
+          uri: 'https://sample-videos.com/audio/mp3/crowd-cheering.mp3',
           size: '1'
         }
       })
@@ -315,7 +316,7 @@ export default {
         content: {
           type: 'video/mp4',
           uri:
-            'http://www.sample-videos.com/video/mp4/720/big_buck_bunny_720p_30mb.mp4',
+            'https://sample-videos.com/video123/mp4/720/big_buck_bunny_720p_1mb.mp4',
           size: '1'
         }
       })
@@ -424,7 +425,14 @@ export default {
       })
       this.send()
     },
-    onUnsupportedType: function(document) {}
+    onUnsupportedType: function(document) {},
+    toogleBlipGroupCard: function() {
+      if (this.showBlipGroupCard) {
+        this.showBlipGroupCard = false
+      } else {
+        this.showBlipGroupCard = true
+      }
+    }
   },
   data: function() {
     return {
@@ -444,7 +452,8 @@ export default {
       msgStatus: 'accepted',
       selected: function(d) {},
       save: function(d) {},
-      deleted: function(d) {}
+      deleted: function(d) {},
+      showBlipGroupCard: true
     }
   },
   components: {}

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+
     <div class="float" style="width: 200px">
       <div>
         <h1>Width:</h1>

--- a/src/components/MediaLink/Audio.vue
+++ b/src/components/MediaLink/Audio.vue
@@ -80,6 +80,11 @@ export default {
     this.initAudio(this.audioUri)
     this.progress = this.$el.querySelector('.progress')
   },
+  destroyed: function() {
+    this.audio.removeEventListener('timeupdate', this.audioTimeUpdated)
+    this.audio.removeEventListener('loadedmetadata', this.audioLoaded)
+    this.audio.removeEventListener('ended', this.resetPlay)
+  },
   methods: {
     init: function() {
       this.audioUri = this.document.uri

--- a/src/components/MediaLink/Video.vue
+++ b/src/components/MediaLink/Video.vue
@@ -148,17 +148,17 @@ export default {
     document.addEventListener('MSFullscreenChange', this.fullScreenChange)
   },
   destroyed: function() {
-    document.addEventListener('fullscreenchange', this.fullScreenChange)
-    document.addEventListener('webkitfullscreenchange', this.fullScreenChange)
-    document.addEventListener('mozfullscreenchange', this.fullScreenChange)
-    document.addEventListener('MSFullscreenChange', this.fullScreenChange)
-    this.video.addEventListener('timeupdate', this.videoTimeUpdated)
-    this.video.addEventListener('loadedmetadata', this.videoLoaded)
-    this.video.addEventListener('seeking', this.readyToPlay)
-    this.video.addEventListener('waiting', this.readyToPlay)
-    this.video.addEventListener('seeked', this.readyToPlay)
-    this.video.addEventListener('canplay', this.readyToPlay)
-    this.video.addEventListener('ended', this.resetPlay)
+    document.removeEventListener('fullscreenchange', this.fullScreenChange)
+    document.removeEventListener('webkitfullscreenchange', this.fullScreenChange)
+    document.removeEventListener('mozfullscreenchange', this.fullScreenChange)
+    document.removeEventListener('MSFullscreenChange', this.fullScreenChange)
+    this.video.removeEventListener('timeupdate', this.videoTimeUpdated)
+    this.video.removeEventListener('loadedmetadata', this.videoLoaded)
+    this.video.removeEventListener('seeking', this.readyToPlay)
+    this.video.removeEventListener('waiting', this.readyToPlay)
+    this.video.removeEventListener('seeked', this.readyToPlay)
+    this.video.removeEventListener('canplay', this.readyToPlay)
+    this.video.removeEventListener('ended', this.resetPlay)
   },
   updated: function() {
     this.initVideo()

--- a/src/components/MediaLink/Video.vue
+++ b/src/components/MediaLink/Video.vue
@@ -147,6 +147,19 @@ export default {
     document.addEventListener('mozfullscreenchange', this.fullScreenChange)
     document.addEventListener('MSFullscreenChange', this.fullScreenChange)
   },
+  destroyed: function() {
+    document.addEventListener('fullscreenchange', this.fullScreenChange)
+    document.addEventListener('webkitfullscreenchange', this.fullScreenChange)
+    document.addEventListener('mozfullscreenchange', this.fullScreenChange)
+    document.addEventListener('MSFullscreenChange', this.fullScreenChange)
+    this.video.addEventListener('timeupdate', this.videoTimeUpdated)
+    this.video.addEventListener('loadedmetadata', this.videoLoaded)
+    this.video.addEventListener('seeking', this.readyToPlay)
+    this.video.addEventListener('waiting', this.readyToPlay)
+    this.video.addEventListener('seeked', this.readyToPlay)
+    this.video.addEventListener('canplay', this.readyToPlay)
+    this.video.addEventListener('ended', this.resetPlay)
+  },
   updated: function() {
     this.initVideo()
   },


### PR DESCRIPTION
- Changed vChatScroll to remove eventListeners on directive destruction
- Changed video and audio components to also remove created eventListeners on destruction
- Included a button to toogle the cards group on/off on main component (and test performance issues)
- Updated video and audio media links (old links were returning 404)