### PR TITLE
fix(directive): Not remove event listener for mousedown

### DIFF
--- a/src/directives/vChatScroll.js
+++ b/src/directives/vChatScroll.js
@@ -58,8 +58,6 @@ import debounce from 'lodash/debounce'
     }
 
     function stop() {
-      el.removeEventListener('mousedown', onMouseDown)
-
       el.classList.remove('ss-grabbed')
       d.body.classList.remove('ss-grabbed')
       d.removeEventListener('mousemove', drag)


### PR DESCRIPTION
vChatScroll directive currently remove event listener for mousedown after the scrollbar be clicked.
This is wrong because if user needs to click again on scrollbar, it won't work.

Currently after mouseup, the event is removed and user cant scroll anymore.
The code is in compliance with https://github.com/buzinas/simple-scrollbar#readme

#227514