### PR TITLE
Adding readonly prop to avoid BlipSelect click

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Then, reference the cards via <blip-card> tag as following
 | on-selected | callback function that will be called when the user interacts with the card (OPTIONAL) | Function (text, option)|
 | on-save | callback function that will be called when the user saves the card after editing (OPTIONAL) | Function (document) |
 | on-deleted | callback function that will be called when the user delete the card (OPTIONAL) | Function (document) |
+| deletable| make the card deletable (OPTIONAL) | Boolean |
 | editable| make the card editable (OPTIONAL) | Boolean |
 | readonly | Currently being used only in the quick reply. Could be implemented in other components too. This is used to avoid click actions in the quick reply options. This attribute might only be used when <em>editable</em> and <em>deletable</em> are false. If <em>editable</em> is setted true, it's behaviour will be priority.(OPTIONAL) | Boolean |
 | hide-options | Used only only in the quick reply. This is used to hide the quick reply options (OPTIONAL) | Boolean |
@@ -58,6 +59,7 @@ Is possible to group your cards using any rule you want. For that use the <blip-
 | on-selected | callback function that will be called when the user interacts with the card (OPTIONAL) | Function (text, option)|
 | on-save | callback function that will be called when the user saves the card after editing (OPTIONAL) | Function (document) |
 | on-deleted | callback function that will be called when the user delete the card (OPTIONAL) | Function (document) |
+| deletable| make the card deletable (OPTIONAL) | Boolean |
 | editable| make the card editable (OPTIONAL) | Boolean |
 | readonly | Currently being used only in the quick reply. Could be implemented in other components too. This is used to avoid click actions in the quick reply options. This attribute might only be used when <em>editable</em> and <em>deletable</em> are false. If <em>editable</em> is setted true, it's behaviour will be priority.(OPTIONAL) | Boolean |
 | hide-options | Used only only in the quick reply. This is used to hide the quick reply options (OPTIONAL) | Boolean |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Then, reference the cards via <blip-card> tag as following
 | on-save | callback function that will be called when the user saves the card after editing (OPTIONAL) | Function (document) |
 | on-deleted | callback function that will be called when the user delete the card (OPTIONAL) | Function (document) |
 | editable| make the card editable (OPTIONAL) | Boolean |
-| hide-options | Used only in the select with scope immediate. This is used to hide the quick reply options (OPTIONAL) | Boolean |
+| readonly | Currently being used only in the quick reply. Could be implemented in other components too. This is used to avoid click actions in the quick reply options. This attribute might only be used when <em>editable</em> and <em>deletable</em> are false. If <em>editable</em> is setted true, it's behaviour will be priority.(OPTIONAL) | Boolean |
+| hide-options | Used only only in the quick reply. This is used to hide the quick reply options (OPTIONAL) | Boolean |
 | disable-link | Used only in the plain text. This is used to do not render tag 'a' (OPTIONAL) | Boolean |
 
 ## Group Card
@@ -58,7 +59,8 @@ Is possible to group your cards using any rule you want. For that use the <blip-
 | on-save | callback function that will be called when the user saves the card after editing (OPTIONAL) | Function (document) |
 | on-deleted | callback function that will be called when the user delete the card (OPTIONAL) | Function (document) |
 | editable| make the card editable (OPTIONAL) | Boolean |
-| hide-options | Used only in the select with scope immediate. This is used to hide the quick reply options (OPTIONAL) | Boolean |
+| readonly | Currently being used only in the quick reply. Could be implemented in other components too. This is used to avoid click actions in the quick reply options. This attribute might only be used when <em>editable</em> and <em>deletable</em> are false. If <em>editable</em> is setted true, it's behaviour will be priority.(OPTIONAL) | Boolean |
+| hide-options | Used only only in the quick reply. This is used to hide the quick reply options (OPTIONAL) | Boolean |
 | disable-link | Used only in the plain text. This is used to do not render tag 'a' (OPTIONAL) | Boolean |
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Then, reference the cards via <blip-card> tag as following
 | on-deleted | callback function that will be called when the user delete the card (OPTIONAL) | Function (document) |
 | deletable| make the card deletable (OPTIONAL) | Boolean |
 | editable| make the card editable (OPTIONAL) | Boolean |
-| readonly | Currently being used only in the quick reply. Could be implemented in other components too. This is used to avoid click actions in the quick reply options. This attribute might only be used when <em>editable</em> and <em>deletable</em> are false. If <em>editable</em> is setted true, it's behaviour will be priority.(OPTIONAL) | Boolean |
+| readonly | Currently being used only in the quick reply. Could be implemented in other components too. This is used to avoid click actions in the quick reply options. If this attribute is true, than the <em>editable</em> and <em>deletable</em> should be false (OPTIONAL) | Boolean |
 | hide-options | Used only only in the quick reply. This is used to hide the quick reply options (OPTIONAL) | Boolean |
 | disable-link | Used only in the plain text. This is used to do not render tag 'a' (OPTIONAL) | Boolean |
 
@@ -61,7 +61,7 @@ Is possible to group your cards using any rule you want. For that use the <blip-
 | on-deleted | callback function that will be called when the user delete the card (OPTIONAL) | Function (document) |
 | deletable| make the card deletable (OPTIONAL) | Boolean |
 | editable| make the card editable (OPTIONAL) | Boolean |
-| readonly | Currently being used only in the quick reply. Could be implemented in other components too. This is used to avoid click actions in the quick reply options. This attribute might only be used when <em>editable</em> and <em>deletable</em> are false. If <em>editable</em> is setted true, it's behaviour will be priority.(OPTIONAL) | Boolean |
+| readonly | Currently being used only in the quick reply. Could be implemented in other components too. This is used to avoid click actions in the quick reply options. If this attribute is true, than the <em>editable</em> and <em>deletable</em> should be false (OPTIONAL) | Boolean |
 | hide-options | Used only only in the quick reply. This is used to hide the quick reply options (OPTIONAL) | Boolean |
 | disable-link | Used only in the plain text. This is used to do not render tag 'a' (OPTIONAL) | Boolean |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "blip-cards",
-  "version": "2.4.4",
+  "version": "2.7.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip-cards",
-  "version": "2.7.4",
+  "version": "2.7.11",
   "description": "Reusable BLiP cards using Vue",
   "license": "MIT",
   "main": "dist/blip-cards.js",

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,7 +14,7 @@
         <br />
         <input type="checkbox" :value="false" v-model="readonly" /> Readonly
         <br />
-       <label style="font-sieze:smaller;color:#bbb"> Readonly property does not apply to every component. Please, checkout the readme.md file!</label>
+       <label style="font-size:smaller;color:#bbb"> Readonly property does not apply to every component. Please, checkout the README.md file!</label>
       </div>
 
       <div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -572,7 +572,7 @@ export default {
       disableLink: false,
       editable: true,
       deletable: true,
-      readonly: this.readonly
+      readonly: false
     }
   },
   components: {}

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,8 @@
         <br />
         <input type="checkbox" :value="true" v-model="deletable" /> Deletable
         <br />
+        <input type="checkbox" :value="false" v-model="readonly" /> Readonly
+        <br />
       </div>
 
       <div>
@@ -153,6 +155,7 @@
           :on-unsupported-type="onUnsupportedType"
           :on-location-error="selected"
           :disable-link="disableLink"
+          :readonly="readonly"
         />
         <div v-else v-for="(item, index) in docs" v-bind:key="index">
           <blip-card
@@ -171,6 +174,7 @@
             :on-unsupported-type="onUnsupportedType"
             :on-location-error="selected"
             :disable-link="disableLink"
+            :readonly="readonly"
           />
         </div>
       </div>
@@ -206,6 +210,7 @@ export default {
         position: this.position,
         status: this.msgStatus
       })
+      console.log(JSON.stringify(this.documents))
     },
     sendText: function () {
       this.json = JSON.stringify({
@@ -566,7 +571,8 @@ export default {
       showBlipGroupCard: true,
       disableLink: false,
       editable: true,
-      deletable: true
+      deletable: true,
+      readonly: this.readonly
     }
   },
   components: {}

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,6 +14,7 @@
         <br />
         <input type="checkbox" :value="false" v-model="readonly" /> Readonly
         <br />
+       <label style="font-sieze:smaller;color:#bbb"> Readonly property does not apply to every component. Please, checkout the readme.md file!</label>
       </div>
 
       <div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -210,7 +210,6 @@ export default {
         position: this.position,
         status: this.msgStatus
       })
-      console.log(JSON.stringify(this.documents))
     },
     sendText: function () {
       this.json = JSON.stringify({

--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -152,7 +152,8 @@
           :deletable="deletable"
           :hide-options="hideOptions"
           :editing="isCardEditing"
-          :on-cancel="cancel"/>
+          :on-cancel="cancel"
+          :readonly="readonly"/>
 
         <web-link
           class="blip-card"
@@ -379,6 +380,10 @@ export default {
     },
     onAudioValidateUri: {
       type: Function
+    },
+    readonly: {
+      type: Boolean,
+      default: false
     }
   },
   data() {

--- a/src/components/BlipGroupCard.vue
+++ b/src/components/BlipGroupCard.vue
@@ -28,6 +28,7 @@
           :class="messageClass(message) + (message.status === 'failed' && message.position === 'right' && group.hasNotification ? ' failed-message' : '')"
           :disable-link="disableLink"
           :on-audio-validate-uri="onAudioValidateUri"
+          :readonly="readonly"
         />
 
         <div class="flex" :class="'group-notification ' + group.position" v-if="group.date && group.hasNotification">
@@ -112,6 +113,9 @@ export default {
     },
     onAudioValidateUri: {
       type: Function
+    },
+    readonly: {
+      type: Boolean
     }
   },
   data() {

--- a/src/components/BlipSelect.vue
+++ b/src/components/BlipSelect.vue
@@ -208,6 +208,10 @@ export default {
     postbackValueMsg: {
       type: String,
       default: 'Postback value'
+    },
+    readonly: {
+      type: Boolean,
+      default: false
     }
   },
   data: function() {
@@ -461,6 +465,8 @@ export default {
     },
     select: debounce(
       function(item) {
+        if (this.readonly) return
+
         if (!this.editable) {
           this.hide = true
         }

--- a/src/components/BlipSelect.vue
+++ b/src/components/BlipSelect.vue
@@ -28,7 +28,7 @@
         <div class="slideshow-list">
           <div class="slideshow-track options">
             <ul class="item-list">
-              <li v-for="(item, index) in options" v-bind:key="index" @click="select(item)" class="disable-selection">
+              <li v-for="(item, index) in options" v-bind:key="index" @click="select(item)" class="disable-selection" v-bind:class="{ readonly: readonly }">
                 <div v-html="sanitize(item.previewText)"></div>
               </li>
             </ul>
@@ -616,6 +616,9 @@ export default {
       width: 12px;
       height: 14px;
     }
+  }
+  &.readonly{
+    cursor: default
   }
 }
 

--- a/src/components/BlipSelect.vue
+++ b/src/components/BlipSelect.vue
@@ -28,7 +28,7 @@
         <div class="slideshow-list">
           <div class="slideshow-track options">
             <ul class="item-list">
-              <li v-for="(item, index) in options" v-bind:key="index" @click="select(item)" class="disable-selection" v-bind:class="{ readonly: readonly && !editable }">
+              <li v-for="(item, index) in options" v-bind:key="index" @click="select(item)" class="disable-selection" v-bind:class="{ readonly: readonly }">
                 <div v-html="sanitize(item.previewText)"></div>
               </li>
             </ul>
@@ -465,7 +465,7 @@ export default {
     },
     select: debounce(
       function(item) {
-        if (this.readonly && !this.editable) return
+        if (this.readonly) return
 
         if (!this.editable) {
           this.hide = true

--- a/src/components/BlipSelect.vue
+++ b/src/components/BlipSelect.vue
@@ -28,7 +28,7 @@
         <div class="slideshow-list">
           <div class="slideshow-track options">
             <ul class="item-list">
-              <li v-for="(item, index) in options" v-bind:key="index" @click="select(item)" class="disable-selection" v-bind:class="{ readonly: readonly }">
+              <li v-for="(item, index) in options" v-bind:key="index" @click="select(item)" class="disable-selection" v-bind:class="{ readonly: readonly && !editable }">
                 <div v-html="sanitize(item.previewText)"></div>
               </li>
             </ul>
@@ -465,7 +465,7 @@ export default {
     },
     select: debounce(
       function(item) {
-        if (this.readonly) return
+        if (this.readonly && !this.editable) return
 
         if (!this.editable) {
           this.hide = true


### PR DESCRIPTION
Added readonly prop to blip-cards to avoid hidding the BlipSelect from QuickReply when visualizing a finished conversation.