### PR TITLE
fix(blipselect): prevent close when visualizing finished thread

### DIFF
--- a/src/components/BlipSelect.vue
+++ b/src/components/BlipSelect.vue
@@ -482,7 +482,9 @@ export default {
             })
           } else {
             this.onSelected(item.text, {
-              content: item.order ? item.order.toString() : item.text,
+              content: item.order 
+              ? item.order.toString() 
+              : item.text,
               type: 'text/plain'
             })
           }


### PR DESCRIPTION
PR created with commit following the `semantic-release` pattern