### PR TITLE
fix(improving blipselect handling when reading finished thread): add …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blip-cards",
-  "version": "2.7.11",
+  "version": "2.7.14",
   "description": "Reusable BLiP cards using Vue",
   "license": "MIT",
   "main": "dist/blip-cards.js",


### PR DESCRIPTION
Added readonly prop to blip-cards to avoid hidding the BlipSelect from QuickReply when visualizing a finished conversation.
