### PR TITLE
fix(BlipCards) - adding 'noopener' property when opening a link in a new page. 

### DIFF
--- a/src/components/Location.vue
+++ b/src/components/Location.vue
@@ -200,7 +200,7 @@ export default {
       })
     },
     handleLocationLink: function() {
-      window.open(this.mapUrl, '_blank')
+      window.open(this.mapUrl, '_blank', 'noopener')
     }
   }
 }

--- a/src/components/MediaLink/BlipFile.vue
+++ b/src/components/MediaLink/BlipFile.vue
@@ -103,7 +103,7 @@ export default {
       if (this.onMediaSelected) {
         this.onMediaSelected(this.document.uri)
       } else {
-        window.open(this.document.uri, '_blank')
+        window.open(this.document.uri, '_blank', 'noopener')
       }
     }
   }

--- a/src/components/MediaLink/Image.vue
+++ b/src/components/MediaLink/Image.vue
@@ -198,7 +198,7 @@ export default {
       if (this.onMediaSelected) {
         this.onMediaSelected(this.document.uri)
       } else {
-        window.open(this.document.uri, '_blank')
+        window.open(this.document.uri, '_blank', 'noopener')
       }
     },
     checkImage(url) {

--- a/src/components/WebLink.vue
+++ b/src/components/WebLink.vue
@@ -175,7 +175,7 @@ export default {
     },
     handleWeblink: function() {
       if (this.target === 'blank') {
-        window.open(this.uri, '_blank')
+        window.open(this.uri, '_blank', 'noopener')
       } else {
         this.onOpenLink({
           uri: this.uri,


### PR DESCRIPTION
adding 'noopener' property when opening a link in a new page. new page cannot overwrite blip-desk page.

![309012610_415793227389945_5803646235345100812_n](https://user-images.githubusercontent.com/26715103/196228344-1a98002c-a66d-4a62-8b29-cf0d33700ad1.png)

![308201875_1107073413260881_578498508069648371_n](https://user-images.githubusercontent.com/26715103/196228301-28cd2cad-2121-415d-9703-8f8524b61e1e.png)

