### PR TITLE
fix: adding 'noopener' property when opening a link in a new page

### DIFF
--- a/src/components/Location.vue
+++ b/src/components/Location.vue
@@ -200,7 +200,7 @@ export default {
       })
     },
     handleLocationLink: function() {
-      window.open(this.mapUrl, '_blank')
+      window.open(this.mapUrl, '_blank', 'noopener')
     }
   }
 }

--- a/src/components/MediaLink/BlipFile.vue
+++ b/src/components/MediaLink/BlipFile.vue
@@ -103,7 +103,7 @@ export default {
       if (this.onMediaSelected) {
         this.onMediaSelected(this.document.uri)
       } else {
-        window.open(this.document.uri, '_blank')
+        window.open(this.document.uri, '_blank', 'noopener')
       }
     }
   }

--- a/src/components/MediaLink/Image.vue
+++ b/src/components/MediaLink/Image.vue
@@ -198,7 +198,7 @@ export default {
       if (this.onMediaSelected) {
         this.onMediaSelected(this.document.uri)
       } else {
-        window.open(this.document.uri, '_blank')
+        window.open(this.document.uri, '_blank', 'noopener')
       }
     },
     checkImage(url) {

--- a/src/components/WebLink.vue
+++ b/src/components/WebLink.vue
@@ -175,7 +175,7 @@ export default {
     },
     handleWeblink: function() {
       if (this.target === 'blank') {
-        window.open(this.uri, '_blank')
+        window.open(this.uri, '_blank', 'noopener')
       } else {
         this.onOpenLink({
           uri: this.uri,


### PR DESCRIPTION
adding 'noopener' property when opening a link in a new page