### PR TITLE
fix: blip file text

### DIFF
--- a/src/components/MediaLink/BlipFile.vue
+++ b/src/components/MediaLink/BlipFile.vue
@@ -8,7 +8,7 @@
         <img :src="editSvg" />
       </div>
       <div v-if="!isEditing" :class="`file-${position}`">
-        <div class="file-wrapper" @click="(editable ? null : handleFileLink())">
+        <div class="file-wrapper" @click="(editable ? null : handleFileLink())" :class="editable ? '' : ' pointer'">
           <div class="file-icon-wrapper">
             <img class="file-icon" :src="mimeType | fileIconFilter"/>
           </div>
@@ -199,15 +199,10 @@ export default {
     }
   }
 
-  .file-right{
-    cursor: pointer;
-  }
-
   .file-left{
     border-radius: 8px;
     background-color: #f2f7fa;
     margin: 5px 5px;
-    cursor: pointer;
   }
 
   .form-group {

--- a/src/components/MediaLink/BlipFile.vue
+++ b/src/components/MediaLink/BlipFile.vue
@@ -7,15 +7,15 @@
       <div v-if="editable && !isEditing" class="editIco" @click="toggleEdit">
         <img :src="editSvg" />
       </div>
-      <div v-if="!isEditing">
-        <div class="file-wrapper" @click="(editable ? null : handleFileLink())" :class="editable ? `file-${position}` : `file-${position} ` + pointer">
+      <div v-if="!isEditing" :class="`file-${position}`">
+        <div class="file-wrapper" @click="(editable ? null : handleFileLink())">
           <div class="file-icon-wrapper">
             <img class="file-icon" :src="mimeType | fileIconFilter"/>
           </div>
           <div class="description-wrapper">
             <div class="link-description">
-              <span v-if="document.title" :title="document.title" class="text big-text">{{ document.title }}</span>
-              <span v-else :title="document.uri" class="text big-text">{{ document.uri }}</span>
+              <span v-if="document.title" :title="document.title" class="text">{{ document.title }}</span>
+              <span v-else :title="document.uri" class="text">{{ document.uri }}</span>
             </div>
             <span v-if="document.size" class="text small-text">{{ document.size | sizeInBytesFilter }}</span>
           </div>
@@ -143,7 +143,7 @@ export default {
       display: flex;
       flex-direction: row;
       align-content: center;
-      justify-content: center;
+      justify-content: flex-start;
 
       .file-icon-wrapper {
         display: flex;
@@ -181,14 +181,10 @@ export default {
         .small-text {
           font-size: 10px;
           font-weight: 100;
+          display: flex;
+          align-items: flex-start;
         }
       }
-    }
-
-    .file-left{
-      border-radius: 8px;
-      background-color: #f2f7fa;
-      margin: 5px 5px;
     }
 
     .file-text {
@@ -201,6 +197,17 @@ export default {
       margin: 0;
       padding: 10px 20px;
     }
+  }
+
+  .file-right{
+    cursor: pointer;
+  }
+
+  .file-left{
+    border-radius: 8px;
+    background-color: #f2f7fa;
+    margin: 5px 5px;
+    cursor: pointer;
   }
 
   .form-group {

--- a/src/components/MediaLink/BlipFile.vue
+++ b/src/components/MediaLink/BlipFile.vue
@@ -8,7 +8,7 @@
         <img :src="editSvg" />
       </div>
       <div v-if="!isEditing">
-        <div class="file-wrapper" @click="(editable ? null : handleFileLink())" :class="editable ? '' : ' pointer'">
+        <div class="file-wrapper" @click="(editable ? null : handleFileLink())" :class="editable ? `file-${position}` : `file-${position} ` + pointer">
           <div class="file-icon-wrapper">
             <img class="file-icon" :src="mimeType | fileIconFilter"/>
           </div>
@@ -38,6 +38,9 @@
             {{ metadataButtonText }}
           </button>
         </form>
+      </div>
+      <div class="file-text" v-if="document.text">
+        <span v-if="document.text" v-html="sanitize(document.text)"></span>
       </div>
     </div>
   </div>
@@ -180,6 +183,23 @@ export default {
           font-weight: 100;
         }
       }
+    }
+
+    .file-left{
+      border-radius: 8px;
+      background-color: #f2f7fa;
+      margin: 5px 5px;
+    }
+
+    .file-text {
+      text-align: left;
+      strong {
+        color: $vue-dark-gray;
+        display: block;
+      }
+
+      margin: 0;
+      padding: 10px 20px;
     }
   }
 


### PR DESCRIPTION
This adjustment aims to correct the presentation of files in the BlipFile component, allowing texts forwarded along with files to be viewed regardless of the origin.

Current format:
![image](https://user-images.githubusercontent.com/42982939/218466960-9ce77fbc-911c-4d3a-a9d6-a51f79fff60b.png)

![image](https://user-images.githubusercontent.com/42982939/218467024-24164ede-2d6b-44f2-a8bd-9b92b1308c45.png)

With PR:

![image](https://user-images.githubusercontent.com/42982939/218467357-ddd744aa-ba52-4eb1-ac88-fb86a5702319.png)

![image](https://user-images.githubusercontent.com/42982939/218467412-edb8e4b4-be8f-4eed-823e-ea19c5db1993.png)
