### PR TITLE
Feature(Component): Create Reply Message Base Component Card

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dev": "node build/dev-server.js --host 0.0.0.0",
     "start": "npm run dev",
     "bundle:min": "cross-env MINIFY=true webpack --progress --config build/webpack.build.config.js",
+    "bundle:watch": "cross-env MINIFY=true webpack --watch --progress --config build/webpack.build.config.js",
     "lint": "eslint --ext .js,.vue src test/unit/specs",
     "semantic-release": "semantic-release"
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -146,6 +146,9 @@
         <button class="button" @click="sendReplyMessageInReplyToReplyButton">
           ENVIAR Reply Message de Reply Buttton
         </button>
+        <button class="button" @click="sendReplyMessageInReplyToReplyButtonWithoutHeader">
+          ENVIAR Reply Message de Reply Buttton sem header
+        </button>
       </div>
 
       <div v-else>
@@ -991,6 +994,55 @@ export default {
                 header: {
                   type: 'text',
                   text: 'header de teste'
+                },
+                footer: {
+                  text: 'rodapé de testes'
+                }
+              }
+            }
+          }
+        }
+      })
+      this.send()
+    },
+    sendReplyMessageInReplyToReplyButtonWithoutHeader: function() {
+      this.json = JSON.stringify({
+        id: 'b1c3398f-ef63-426d-98b8-37ca84478f8f',
+        to: 'to@msging.net',
+        from: 'from@msging.net',
+        type: 'application/vnd.lime.reply+json',
+        content: {
+          replied: {
+            type: 'text/plain',
+            value: 'replied text'
+          },
+          inReplyTo: {
+            type: 'application/json',
+            value: {
+              recipient_type: 'individual',
+              type: 'interactive',
+              interactive: {
+                type: 'button',
+                body: {
+                  text: 'conteúdo de teste'
+                },
+                action: {
+                  buttons: [
+                    {
+                      type: 'reply',
+                      reply: {
+                        id: '1',
+                        title: 'botão 1'
+                      }
+                    },
+                    {
+                      type: 'reply',
+                      reply: {
+                        id: '2',
+                        title: 'botão 2'
+                      }
+                    }
+                  ]
                 },
                 footer: {
                   text: 'rodapé de testes'

--- a/src/App.vue
+++ b/src/App.vue
@@ -134,6 +134,9 @@
         <button class="button" @click="sendReplyMessage">
           ENVIAR Reply Message
         </button>
+        <button class="button" @click="sendReplyMessageInReplyToMenu">
+          ENVIAR Reply Message de Menu
+        </button>
       </div>
 
       <div v-else>
@@ -789,6 +792,39 @@ export default {
             id: 'b1c3398f-ef63-426d-98b8-37ca84478f8f',
             type: 'text/plain',
             value: 'in reply to text'
+          }
+        }
+      })
+      this.send()
+    },
+    sendReplyMessageInReplyToMenu: function() {
+      this.json = JSON.stringify({
+        id: 'b1c3398f-ef63-426d-98b8-37ca84478f8f',
+        to: 'to@msging.net',
+        from: 'from@msging.net',
+        type: 'application/vnd.lime.reply+json',
+        content: {
+          replied: {
+            type: 'text/plain',
+            value: 'replied text'
+          },
+          inReplyTo: {
+            id: 'b1c3398f-ef63-426d-98b8-37ca84478f8f',
+            type: 'application/vnd.lime.select+json',
+            value: {
+              scope: 'immediate',
+              text: 'Choose an option',
+              options: [
+                { text: 'First option' },
+                { order: '2', text: 'Second option' },
+                {
+                  order: '3',
+                  text: 'Third option',
+                  type: 'application/json',
+                  value: { key1: 'value1', key2: '2' }
+                }
+              ]
+            }
           }
         }
       })

--- a/src/App.vue
+++ b/src/App.vue
@@ -131,6 +131,9 @@
         <button class="button" @click="sendReplyButton">
           ENVIAR Reply Button
         </button>
+        <button class="button" @click="sendReplyMessage">
+          ENVIAR Reply Message
+        </button>
       </div>
 
       <div v-else>
@@ -766,6 +769,26 @@ export default {
             footer: {
               text: 'rodapé de testes'
             }
+          }
+        }
+      })
+      this.send()
+    },
+    sendReplyMessage: function() {
+      this.json = JSON.stringify({
+        id: 'b1c3398f-ef63-426d-98b8-37ca84478f8f',
+        to: 'to@msging.net',
+        from: 'from@msging.net',
+        type: 'application/vnd.lime.reply+json',
+        content: {
+          replied: {
+            type: 'text/plain',
+            value: 'text'
+          },
+          inReplyTo: {
+            id: 'b1c3398f-ef63-426d-98b8-37ca84478f8f',
+            type: 'text/plain',
+            value: 'text'
           }
         }
       })

--- a/src/App.vue
+++ b/src/App.vue
@@ -783,12 +783,12 @@ export default {
         content: {
           replied: {
             type: 'text/plain',
-            value: 'text'
+            value: 'replied text'
           },
           inReplyTo: {
             id: 'b1c3398f-ef63-426d-98b8-37ca84478f8f',
             type: 'text/plain',
-            value: 'text'
+            value: 'in reply to text'
           }
         }
       })

--- a/src/App.vue
+++ b/src/App.vue
@@ -137,6 +137,15 @@
         <button class="button" @click="sendReplyMessageInReplyToMenu">
           ENVIAR Reply Message de Menu
         </button>
+        <button class="button" @click="sendReplyMessageInReplyToMenuList">
+          ENVIAR Reply Message de Menu List
+        </button>
+        <button class="button" @click="sendReplyMessageInReplyToMenuListMultiSection">
+          ENVIAR Reply Message de Menu List Multi Section
+        </button>
+        <button class="button" @click="sendReplyMessageInReplyToReplyButton">
+          ENVIAR Reply Message de Reply Buttton
+        </button>
       </div>
 
       <div v-else>
@@ -824,6 +833,169 @@ export default {
                   value: { key1: 'value1', key2: '2' }
                 }
               ]
+            }
+          }
+        }
+      })
+      this.send()
+    },
+    sendReplyMessageInReplyToMenuList: function() {
+      this.json = JSON.stringify({
+        id: 'b1c3398f-ef63-426d-98b8-37ca84478f8f',
+        to: 'to@msging.net',
+        from: 'from@msging.net',
+        type: 'application/vnd.lime.reply+json',
+        content: {
+          replied: {
+            type: 'text/plain',
+            value: 'replied text'
+          },
+          inReplyTo: {
+            type: 'application/json',
+            value: {
+              recipient_type: 'individual',
+              type: 'interactive',
+              interactive: {
+                type: 'list',
+                header: {
+                  type: 'text',
+                  text: 'E então, com qual assunto posso te ajudar?'
+                },
+                body: {
+                  text: 'Clique para abrir as opções 👇'
+                },
+                action: {
+                  button: 'Escolher assunto',
+                  sections: [
+                    {
+                      rows: [
+                        {
+                          id: 'id:1.0',
+                          title: '🤖 Como funciona?',
+                          description: 'Entender como o Blip funciona, seus benefícios, preços e mais'
+                        },
+                        {
+                          id: 'id:1.1',
+                          title: '🤝 Contratar Take Blip',
+                          description: 'Quero conversar com o time de vendas para tirar dúvidas e contratar'
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      })
+      this.send()
+    },
+    sendReplyMessageInReplyToMenuListMultiSection: function() {
+      this.json = JSON.stringify({
+        id: 'b1c3398f-ef63-426d-98b8-37ca84478f8f',
+        to: 'to@msging.net',
+        from: 'from@msging.net',
+        type: 'application/vnd.lime.reply+json',
+        content: {
+          replied: {
+            type: 'text/plain',
+            value: 'replied text'
+          },
+          inReplyTo: {
+            type: 'application/json',
+            value: {
+              type: 'interactive',
+              interactive: {
+                type: 'list',
+                header: {
+                  type: 'text',
+                  text: 'header-content'
+                },
+                body: {
+                  text: 'text-body-content'
+                },
+                footer: {
+                  text: 'footer-content'
+                },
+                action: {
+                  button: 'Choose subject',
+                  sections: [
+                    {
+                      title: 'Section 1',
+                      rows: [
+                        {
+                          id: '1',
+                          title: '💬 My row 1',
+                          description: 'My row 1 description'
+                        }
+                      ]
+                    },
+                    {
+                      title: 'Section 2',
+                      rows: [
+                        {
+                          id: '2',
+                          title: '💬 My row 2',
+                          description: 'My row 2 description'
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      })
+      this.send()
+    },
+    sendReplyMessageInReplyToReplyButton: function() {
+      this.json = JSON.stringify({
+        id: 'b1c3398f-ef63-426d-98b8-37ca84478f8f',
+        to: 'to@msging.net',
+        from: 'from@msging.net',
+        type: 'application/vnd.lime.reply+json',
+        content: {
+          replied: {
+            type: 'text/plain',
+            value: 'replied text'
+          },
+          inReplyTo: {
+            type: 'application/json',
+            value: {
+              recipient_type: 'individual',
+              type: 'interactive',
+              interactive: {
+                type: 'button',
+                body: {
+                  text: 'conteúdo de teste'
+                },
+                action: {
+                  buttons: [
+                    {
+                      type: 'reply',
+                      reply: {
+                        id: '1',
+                        title: 'botão 1'
+                      }
+                    },
+                    {
+                      type: 'reply',
+                      reply: {
+                        id: '2',
+                        title: 'botão 2'
+                      }
+                    }
+                  ]
+                },
+                header: {
+                  type: 'text',
+                  text: 'header de teste'
+                },
+                footer: {
+                  text: 'rodapé de testes'
+                }
+              }
             }
           }
         }

--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -370,9 +370,7 @@
           :deletable="deletable"
           :editing="isCardEditing"
           :on-cancel="cancel"
-          :translations="translations"
-        >
-        </reply-card>
+          :translations="translations" />
 
         <unsuported-content
           v-else

--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -354,6 +354,26 @@
           :on-cancel="cancel"
           :translations="translations" />
 
+        <reply-card
+          v-else-if="document.type === 'application/vnd.lime.reply+json'"
+          class="blip-card"
+          :failed-to-send-msg="translations.failedToSend"
+          :status="status"
+          :position="position"
+          :document="editableDocument.content"
+          :full-document="editableDocument"
+          :date="date"
+          :on-save="saveCard"
+          :editable="editable"
+          :on-deleted="deleteCard"
+          :on-metadata-edit="isMetadataReady"
+          :deletable="deletable"
+          :editing="isCardEditing"
+          :on-cancel="cancel"
+          :translations="translations"
+        >
+        </reply-card>
+
         <unsuported-content
           v-else
           class="blip-card"

--- a/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
+++ b/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
@@ -10,12 +10,10 @@
   </div>
 </template>
   
-  <script>
-  import { default as base } from '../../../mixins/baseComponent.js'
-  
+<script>
   export default {
     name: 'in-reply-to-base',
-    mixins: [base],
+    mixins: [],
     props: {
       inReplyTo: {
         type: Object,
@@ -37,35 +35,35 @@
     methods: {
     }
   }
-  </script>
+</script>
   
-  <style lang="scss" scoped>
+<style lang="scss" scoped>
   @import '../../../styles/variables.scss';
 
   .in-reply-to-message-bar {
-  flex: none;
-  width: 4px;
-  border-top-left-radius: 8px;
-  border-bottom-left-radius: 8px;
-  background-color: $color-primary;
+    flex: none;
+    width: 4px;
+    border-top-left-radius: 8px;
+    border-bottom-left-radius: 8px;
+    background-color: $color-primary;
 
 
-  &.own-message {
-    background-color: $color-content-ghost;
+    &.own-message {
+      background-color: $color-content-ghost;
+    }
   }
-}
 
-.in-reply-to-message-container {
-  display: flex;
-  overflow: hidden;
-  background-color: #E0E0E0;
-  border: 1px solid #949494;
-  border-radius: 0.5rem;
-  margin: 1rem 0;
-}
+  .in-reply-to-message-container {
+    display: flex;
+    overflow: hidden;
+    background-color: #E0E0E0;
+    border: 1px solid #949494;
+    border-radius: 0.5rem;
+    margin: 1rem 0;
+  }
 
-.in-reply-to-message {
-  padding: 0.5rem;
-}
+  .in-reply-to-message {
+    padding: 0.5rem;
+  }
 </style>
   

--- a/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
+++ b/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
@@ -36,11 +36,6 @@
       menuValue() {
         return this.inReplyTo.value.text
       }
-    },
-    created() {
-      console.log(this.inReplyTo)
-    },
-    methods: {
     }
   }
 </script>

--- a/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
+++ b/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
@@ -6,6 +6,11 @@
         v-if="inReplyTo.type === 'text/plain'"
         :text="inReplyToValue"
       />
+
+      <in-reply-to-text 
+        v-else-if="inReplyTo.type === 'application/vnd.lime.select+json'"
+        :text="menuValue"
+      />
     </div>
   </div>
 </template>
@@ -27,6 +32,9 @@
     computed: {
       inReplyToValue() {
         return this.inReplyTo.value
+      },
+      menuValue() {
+        return this.inReplyTo.value.text
       }
     },
     created() {

--- a/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
+++ b/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="in-reply-to-message-container">
+    <span class="in-reply-to-message-bar" :class="{ 'own-message': isOwnMessage }"></span>
+    <div class="in-reply-to-message">
+      <in-reply-to-text 
+        v-if="inReplyTo.type === 'text/plain'"
+        :text="inReplyToValue"
+      />
+    </div>
+  </div>
+</template>
+  
+  <script>
+  import { default as base } from '../../../mixins/baseComponent.js'
+  
+  export default {
+    name: 'in-reply-to-base',
+    mixins: [base],
+    props: {
+      inReplyTo: {
+        type: Object,
+        default: {}
+      },
+      isOwnMessage: {
+        type: Boolean,
+        default: false
+      }
+    },
+    computed: {
+      inReplyToValue() {
+        return this.inReplyTo.value
+      }
+    },
+    created() {
+      console.log(this.inReplyTo)
+    },
+    methods: {
+    }
+  }
+  </script>
+  
+  <style lang="scss" scoped>
+  @import '../../../styles/variables.scss';
+
+  .in-reply-to-message-bar {
+  flex: none;
+  width: 4px;
+  border-top-left-radius: 8px;
+  border-bottom-left-radius: 8px;
+  background-color: $color-primary;
+
+
+  &.own-message {
+    background-color: $color-content-ghost;
+  }
+}
+
+.in-reply-to-message-container {
+  display: flex;
+  overflow: hidden;
+  background-color: #E0E0E0;
+  border: 1px solid #949494;
+  border-radius: 0.5rem;
+  margin: 1rem 0;
+}
+
+.in-reply-to-message {
+  padding: 0.5rem;
+}
+</style>
+  

--- a/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
+++ b/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
@@ -13,9 +13,16 @@
       />
 
       <in-reply-to-text 
-        v-else-if="inReplyTo.type === 'application/json' && (isInteractiveTypeListWithTextHeader || isInteractiveTypeButtonWithTextHeader)"
-        :text="applicationJsonTitleTextValue"
-        :description="applicationJsonDescriptionTextValue"
+        v-else-if="
+          inReplyTo.type === 'application/json' &&
+          (
+            isInteractiveTypeListWithTextHeader ||
+            isInteractiveTypeButtonWithTextHeader ||
+            isInteractiveTypeButtonWithoutTextHeader
+          )
+        "
+        :text="isInteractiveTypeButtonWithoutTextHeader ? applicationJsonDescriptionTextValue : applicationJsonTitleTextValue"
+        :description="isInteractiveTypeButtonWithoutTextHeader ? '' : applicationJsonDescriptionTextValue"
       />
     </div>
   </div>
@@ -49,10 +56,18 @@
         return this.inReplyTo.value.interactive.body.text
       },
       isInteractiveTypeButtonWithTextHeader() {
-        return this.inReplyTo.value.interactive.type === 'button' && this.inReplyTo.value.interactive.header.type === 'text'
+        return this.inReplyTo.value.interactive.type === 'button' &&
+          this.inReplyTo.value.interactive.header &&
+          this.inReplyTo.value.interactive.header.type === 'text'
+      },
+      isInteractiveTypeButtonWithoutTextHeader() {
+        return this.inReplyTo.value.interactive.type === 'button' &&
+          !this.inReplyTo.value.interactive.header &&
+          Boolean(this.inReplyTo.value.interactive.body.text)
       },
       isInteractiveTypeListWithTextHeader() {
-        return this.inReplyTo.value.interactive.type === 'list' && this.inReplyTo.value.interactive.header.type === 'text'
+        return this.inReplyTo.value.interactive.type === 'list' &&
+          this.inReplyTo.value.interactive.header.type === 'text'
       }
     }
   }

--- a/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
+++ b/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
@@ -4,12 +4,18 @@
     <div class="in-reply-to-message">
       <in-reply-to-text 
         v-if="inReplyTo.type === 'text/plain'"
-        :text="inReplyToValue"
+        :text="textValue"
       />
 
       <in-reply-to-text 
         v-else-if="inReplyTo.type === 'application/vnd.lime.select+json'"
-        :text="menuValue"
+        :text="menuTextValue"
+      />
+
+      <in-reply-to-text 
+        v-else-if="inReplyTo.type === 'application/json' && (isInteractiveTypeListWithTextHeader || isInteractiveTypeButtonWithTextHeader)"
+        :text="applicationJsonTitleTextValue"
+        :description="applicationJsonDescriptionTextValue"
       />
     </div>
   </div>
@@ -30,11 +36,23 @@
       }
     },
     computed: {
-      inReplyToValue() {
+      textValue() {
         return this.inReplyTo.value
       },
-      menuValue() {
+      menuTextValue() {
         return this.inReplyTo.value.text
+      },
+      applicationJsonTitleTextValue() {
+        return this.inReplyTo.value.interactive.header.text
+      },
+      applicationJsonDescriptionTextValue() {
+        return this.inReplyTo.value.interactive.body.text
+      },
+      isInteractiveTypeButtonWithTextHeader() {
+        return this.inReplyTo.value.interactive.type === 'button' && this.inReplyTo.value.interactive.header.type === 'text'
+      },
+      isInteractiveTypeListWithTextHeader() {
+        return this.inReplyTo.value.interactive.type === 'list' && this.inReplyTo.value.interactive.header.type === 'text'
       }
     }
   }

--- a/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
+++ b/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
@@ -59,8 +59,8 @@
   .in-reply-to-message-container {
     display: flex;
     overflow: hidden;
-    background-color: #E0E0E0;
-    border: 1px solid #949494;
+    background-color: $color-surface-3;
+    border: 1px solid $color-content-ghost;
     border-radius: 0.5rem;
     margin: 1rem 0;
   }

--- a/src/components/ReplyCard/InReplyTo/InReplyToText.vue
+++ b/src/components/ReplyCard/InReplyTo/InReplyToText.vue
@@ -16,11 +16,6 @@
       inReplyToText() {
         return this.text
       }
-    },
-    created() {
-      console.log(this.text)
-    },
-    methods: {
     }
   }
 </script>

--- a/src/components/ReplyCard/InReplyTo/InReplyToText.vue
+++ b/src/components/ReplyCard/InReplyTo/InReplyToText.vue
@@ -1,0 +1,43 @@
+<template>
+  <bds-typo tag="p" variant="fs-16" bold="regular" margin="false" class="message-replied-text">{{ inReplyToText }}</bds-typo>
+</template>
+  
+  <script>
+  import { default as base } from '../../../mixins/baseComponent.js'
+  
+  export default {
+    name: 'in-reply-to-text',
+    mixins: [base],
+    props: {
+      text: {
+        type: String,
+        default: ''
+      }
+    },
+    computed: {
+      inReplyToText() {
+        return this.text
+      }
+    },
+    created() {
+      console.log(this.text)
+    },
+    methods: {
+    }
+  }
+  </script>
+  
+  <style lang="scss" scoped>
+  @import '../../../styles/variables.scss';
+
+  .message-replied-text {
+  display: -webkit-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  margin: 0;
+  text-align: left;
+}
+  </style>
+  

--- a/src/components/ReplyCard/InReplyTo/InReplyToText.vue
+++ b/src/components/ReplyCard/InReplyTo/InReplyToText.vue
@@ -2,12 +2,10 @@
   <bds-typo tag="p" variant="fs-16" bold="regular" margin="false" class="message-replied-text">{{ inReplyToText }}</bds-typo>
 </template>
   
-  <script>
-  import { default as base } from '../../../mixins/baseComponent.js'
-  
+<script>
   export default {
     name: 'in-reply-to-text',
-    mixins: [base],
+    mixins: [],
     props: {
       text: {
         type: String,
@@ -25,19 +23,19 @@
     methods: {
     }
   }
-  </script>
+</script>
   
-  <style lang="scss" scoped>
+<style lang="scss" scoped>
   @import '../../../styles/variables.scss';
 
   .message-replied-text {
-  display: -webkit-box;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  margin: 0;
-  text-align: left;
-}
-  </style>
+    display: -webkit-box;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    margin: 0;
+    text-align: left;
+  }
+</style>
   

--- a/src/components/ReplyCard/InReplyTo/InReplyToText.vue
+++ b/src/components/ReplyCard/InReplyTo/InReplyToText.vue
@@ -1,5 +1,20 @@
 <template>
-  <bds-typo tag="p" variant="fs-16" bold="regular" margin="false" class="message-replied-text">{{ inReplyToText }}</bds-typo>
+  <div>
+    <bds-typo
+      tag="p"
+      variant="fs-16"
+      :bold="hasDescription ? 'bold' : 'regular'"
+      margin="false"
+      class="message-replied-text"
+      :class="{ 'single': !hasDescription, 'title': hasDescription }">{{ inReplyToText }}</bds-typo>
+    <bds-typo 
+      v-if="hasDescription"
+      tag="p"
+      variant="fs-16"
+      bold="regular"
+      margin="false"
+      class="message-replied-text description">{{ inReplyToDescription }}</bds-typo>
+  </div>
 </template>
   
 <script>
@@ -10,11 +25,21 @@
       text: {
         type: String,
         default: ''
+      },
+      description: {
+        type: String,
+        default: ''
       }
     },
     computed: {
       inReplyToText() {
         return this.text
+      },
+      inReplyToDescription() {
+        return this.description
+      },
+      hasDescription() {
+        return Boolean(this.description)
       }
     }
   }
@@ -27,10 +52,21 @@
     display: -webkit-box;
     overflow: hidden;
     text-overflow: ellipsis;
-    -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     margin: 0;
     text-align: left;
+
+    &.single {
+      -webkit-line-clamp: 3;
+    }
+
+    &.title {
+      -webkit-line-clamp: 1;
+    }
+
+    &.description {
+      -webkit-line-clamp: 2;
+    }
   }
 </style>
   

--- a/src/components/ReplyCard/Replied/RepliedBase.vue
+++ b/src/components/ReplyCard/Replied/RepliedBase.vue
@@ -21,11 +21,6 @@
       repliedValue() {
         return this.replied.value
       }
-    },
-    created() {
-      console.log(this.replied)
-    },
-    methods: {
     }
   }
 </script>

--- a/src/components/ReplyCard/Replied/RepliedBase.vue
+++ b/src/components/ReplyCard/Replied/RepliedBase.vue
@@ -1,18 +1,16 @@
 <template>
-    <div>
-        <replied-with-text 
-            v-if="replied.type === 'text/plain'"
-            :text="repliedValue"
-        />
-    </div>
+  <div>
+    <replied-with-text 
+      v-if="replied.type === 'text/plain'"
+      :text="repliedValue"
+    />
+  </div>
 </template>
   
-  <script>
-  import { default as base } from '../../../mixins/baseComponent.js'
-  
+<script>
   export default {
     name: 'replied-base',
-    mixins: [base],
+    mixins: [],
     props: {
       replied: {
         type: Object,
@@ -30,9 +28,5 @@
     methods: {
     }
   }
-  </script>
-  
-  <style lang="scss" scoped>
-  @import '../../../styles/variables.scss';
-  </style>
+</script>
   

--- a/src/components/ReplyCard/Replied/RepliedBase.vue
+++ b/src/components/ReplyCard/Replied/RepliedBase.vue
@@ -1,0 +1,38 @@
+<template>
+    <div>
+        <replied-with-text 
+            v-if="replied.type === 'text/plain'"
+            :text="repliedValue"
+        />
+    </div>
+</template>
+  
+  <script>
+  import { default as base } from '../../../mixins/baseComponent.js'
+  
+  export default {
+    name: 'replied-base',
+    mixins: [base],
+    props: {
+      replied: {
+        type: Object,
+        default: {}
+      }
+    },
+    computed: {
+      repliedValue() {
+        return this.replied.value
+      }
+    },
+    created() {
+      console.log(this.replied)
+    },
+    methods: {
+    }
+  }
+  </script>
+  
+  <style lang="scss" scoped>
+  @import '../../../styles/variables.scss';
+  </style>
+  

--- a/src/components/ReplyCard/Replied/RepliedWithText.vue
+++ b/src/components/ReplyCard/Replied/RepliedWithText.vue
@@ -18,11 +18,6 @@
       repliedText() {
         return this.text
       }
-    },
-    created() {
-      console.log(this.document)
-    },
-    methods: {
     }
   }
 </script>

--- a/src/components/ReplyCard/Replied/RepliedWithText.vue
+++ b/src/components/ReplyCard/Replied/RepliedWithText.vue
@@ -1,0 +1,35 @@
+<template>
+    <div>
+        <bds-typo tag="span" variant="fs-16" margin="false">{{ repliedText }}</bds-typo>
+    </div>
+</template>
+  
+  <script>
+  import { default as base } from '../../../mixins/baseComponent.js'
+  
+  export default {
+    name: 'replied-with-text',
+    mixins: [base],
+    props: {
+      text: {
+        type: String,
+        default: ''
+      }
+    },
+    computed: {
+      repliedText() {
+        return this.text
+      }
+    },
+    created() {
+      console.log(this.document)
+    },
+    methods: {
+    }
+  }
+  </script>
+  
+  <style lang="scss" scoped>
+  @import '../../../styles/variables.scss';
+  </style>
+  

--- a/src/components/ReplyCard/Replied/RepliedWithText.vue
+++ b/src/components/ReplyCard/Replied/RepliedWithText.vue
@@ -1,15 +1,13 @@
 <template>
-    <div>
-        <bds-typo tag="span" variant="fs-16" margin="false">{{ repliedText }}</bds-typo>
-    </div>
+  <div>
+    <bds-typo tag="span" variant="fs-16" margin="false">{{ repliedText }}</bds-typo>
+  </div>
 </template>
   
-  <script>
-  import { default as base } from '../../../mixins/baseComponent.js'
-  
+<script>
   export default {
     name: 'replied-with-text',
-    mixins: [base],
+    mixins: [],
     props: {
       text: {
         type: String,
@@ -27,9 +25,5 @@
     methods: {
     }
   }
-  </script>
-  
-  <style lang="scss" scoped>
-  @import '../../../styles/variables.scss';
-  </style>
+</script>
   

--- a/src/components/ReplyCard/ReplyCard.vue
+++ b/src/components/ReplyCard/ReplyCard.vue
@@ -1,0 +1,99 @@
+<template>
+  <div class="blip-container reply-card">
+    <div :class="'bubble ' + position">
+      <div class="reply-container">
+        <div class="reply-header">
+          <bds-icon name="undo" theme="outline" aria-label="Reply icon"></bds-icon>
+          <bds-typo tag="p" variant="fs-14" bold="regular" italic="true">Resposta</bds-typo>
+        </div>
+
+        <div class="message-replied-container">
+          <span class="message-replied-bar" :class="{ 'own-message': isOwnMessage }"></span>
+          <div class="message-replied">
+            <bds-typo tag="p" variant="fs-16" bold="regular" margin="false" class="message-replied-text">{{ messageRepliedText }}</bds-typo>
+          </div>
+        </div>
+
+        <div>
+          <bds-typo tag="span" variant="fs-16" margin="false">{{ reply }}</bds-typo>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { default as base } from '../../mixins/baseComponent.js'
+
+export default {
+  name: 'reply-card',
+  mixins: [base],
+  computed: {
+    isOwnMessage() {
+      return this.fullDocument.direction === this.fullDocument.content.inReplyTo.direction
+    },
+    reply() {
+      return this.document.replied.value
+    },
+    messageRepliedText() {
+      return this.document.inReplyTo.value
+    }
+  },
+  created() {
+    console.log(this.document)
+  },
+  methods: {
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '../../styles/variables.scss';
+
+.reply-container {
+  text-align: left;
+  padding: 1rem;
+}
+
+.reply-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.message-replied-bar {
+  flex: none;
+  width: 4px;
+  border-top-left-radius: 8px;
+  border-bottom-left-radius: 8px;
+  background-color: $color-primary;
+
+
+  &.own-message {
+    background-color: $color-content-ghost;
+  }
+}
+
+.message-replied-container {
+  display: flex;
+  overflow: hidden;
+  background-color: #E0E0E0;
+  border: 1px solid #949494;
+  border-radius: 0.5rem;
+  margin: 1rem 0;
+}
+
+.message-replied {
+  padding: 0.5rem;
+}
+
+.message-replied-text {
+  display: -webkit-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  margin: 0;
+  text-align: left;
+}
+</style>

--- a/src/components/ReplyCard/ReplyCard.vue
+++ b/src/components/ReplyCard/ReplyCard.vue
@@ -10,9 +10,11 @@
         <replied-base :replied="replied" />
       </div>
     </div>
-    <div class="flex" :class="'notification ' + position" v-if="date">
-      {{ date }}
-    </div>
+    <blip-card-date
+      :status="status"
+      :position="position"
+      :date="date"
+      :failed-to-send-msg="failedToSendMsg" />
   </div>
 </template>
 

--- a/src/components/ReplyCard/ReplyCard.vue
+++ b/src/components/ReplyCard/ReplyCard.vue
@@ -14,47 +14,47 @@
 </template>
 
 <script>
-import { default as base } from '../../mixins/baseComponent.js'
+  import { default as base } from '../../mixins/baseComponent.js'
 
-export default {
-  name: 'reply-card',
-  mixins: [base],
-  props: {
-    translations: {
-      type: Object,
-      default: () => ({})
-    }
-  },
-  computed: {
-    isOwnMessage() {
-      return this.fullDocument.direction === this.fullDocument.content.inReplyTo.direction
+  export default {
+    name: 'reply-card',
+    mixins: [base],
+    props: {
+      translations: {
+        type: Object,
+        default: () => ({})
+      }
     },
-    replied() {
-      return this.document.replied
+    computed: {
+      isOwnMessage() {
+        return this.fullDocument.direction === this.fullDocument.content.inReplyTo.direction
+      },
+      replied() {
+        return this.document.replied
+      },
+      inReplyTo() {
+        return this.document.inReplyTo
+      }
     },
-    inReplyTo() {
-      return this.document.inReplyTo
+    created() {
+      console.log(this.document)
+    },
+    methods: {
     }
-  },
-  created() {
-    console.log(this.document)
-  },
-  methods: {
   }
-}
 </script>
 
 <style lang="scss" scoped>
-@import '../../styles/variables.scss';
+  @import '../../styles/variables.scss';
 
-.reply-container {
-  text-align: left;
-  padding: 1rem;
-}
+  .reply-container {
+    text-align: left;
+    padding: 1rem;
+  }
 
-.reply-header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
+  .reply-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
 </style>

--- a/src/components/ReplyCard/ReplyCard.vue
+++ b/src/components/ReplyCard/ReplyCard.vue
@@ -10,6 +10,9 @@
         <replied-base :replied="replied" />
       </div>
     </div>
+    <div class="flex" :class="'notification ' + position" v-if="date">
+      {{ date }}
+    </div>
   </div>
 </template>
 

--- a/src/components/ReplyCard/ReplyCard.vue
+++ b/src/components/ReplyCard/ReplyCard.vue
@@ -28,6 +28,14 @@
       translations: {
         type: Object,
         default: () => ({})
+      },
+      failedToSendMsg: {
+        type: String,
+        default: 'Falha ao enviar a mensagem'
+      },
+      status: {
+        type: String,
+        default: ''
       }
     },
     computed: {
@@ -40,11 +48,6 @@
       inReplyTo() {
         return this.document.inReplyTo
       }
-    },
-    created() {
-      console.log(this.document)
-    },
-    methods: {
     }
   }
 </script>

--- a/src/components/ReplyCard/ReplyCard.vue
+++ b/src/components/ReplyCard/ReplyCard.vue
@@ -6,7 +6,7 @@
           <bds-icon name="undo" theme="outline" aria-label="Reply icon"></bds-icon>
           <bds-typo tag="p" variant="fs-14" bold="regular" italic="true">{{ translations.reply || 'Resposta' }}</bds-typo>
         </div>
-        <in-reply-to-base :inReplyTo="inReplyTo" :isOwnMessage="isOwnMessage" />
+        <in-reply-to-base :in-reply-to="inReplyTo" :is-own-message="isOwnMessage" />
         <replied-base :replied="replied" />
       </div>
     </div>

--- a/src/components/ReplyCard/ReplyCard.vue
+++ b/src/components/ReplyCard/ReplyCard.vue
@@ -4,19 +4,10 @@
       <div class="reply-container">
         <div class="reply-header">
           <bds-icon name="undo" theme="outline" aria-label="Reply icon"></bds-icon>
-          <bds-typo tag="p" variant="fs-14" bold="regular" italic="true">Resposta</bds-typo>
+          <bds-typo tag="p" variant="fs-14" bold="regular" italic="true">{{ translations.reply || 'Resposta' }}</bds-typo>
         </div>
-
-        <div class="message-replied-container">
-          <span class="message-replied-bar" :class="{ 'own-message': isOwnMessage }"></span>
-          <div class="message-replied">
-            <bds-typo tag="p" variant="fs-16" bold="regular" margin="false" class="message-replied-text">{{ messageRepliedText }}</bds-typo>
-          </div>
-        </div>
-
-        <div>
-          <bds-typo tag="span" variant="fs-16" margin="false">{{ reply }}</bds-typo>
-        </div>
+        <in-reply-to-base :inReplyTo="inReplyTo" :isOwnMessage="isOwnMessage" />
+        <replied-base :replied="replied" />
       </div>
     </div>
   </div>
@@ -28,15 +19,21 @@ import { default as base } from '../../mixins/baseComponent.js'
 export default {
   name: 'reply-card',
   mixins: [base],
+  props: {
+    translations: {
+      type: Object,
+      default: () => ({})
+    }
+  },
   computed: {
     isOwnMessage() {
       return this.fullDocument.direction === this.fullDocument.content.inReplyTo.direction
     },
-    reply() {
-      return this.document.replied.value
+    replied() {
+      return this.document.replied
     },
-    messageRepliedText() {
-      return this.document.inReplyTo.value
+    inReplyTo() {
+      return this.document.inReplyTo
     }
   },
   created() {
@@ -59,41 +56,5 @@ export default {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-}
-
-.message-replied-bar {
-  flex: none;
-  width: 4px;
-  border-top-left-radius: 8px;
-  border-bottom-left-radius: 8px;
-  background-color: $color-primary;
-
-
-  &.own-message {
-    background-color: $color-content-ghost;
-  }
-}
-
-.message-replied-container {
-  display: flex;
-  overflow: hidden;
-  background-color: #E0E0E0;
-  border: 1px solid #949494;
-  border-radius: 0.5rem;
-  margin: 1rem 0;
-}
-
-.message-replied {
-  padding: 0.5rem;
-}
-
-.message-replied-text {
-  display: -webkit-box;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  margin: 0;
-  text-align: left;
 }
 </style>

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ import BlipCardDate from './components/BlipCardDate'
 import ApplicationJSon from './components/ApplicationJSon'
 import MenuListPrompt from './components/ApplicationJSon/MenuListPrompt'
 import MenuList from './components/ApplicationJSon/MenuList'
+import ReplyCard from './components/ReplyCard/ReplyCard'
 
 // Validators
 import JsonValidator from './validators/jsonValidator'
@@ -73,6 +74,7 @@ function install(Vue) {
   components.push(Vue.component(ApplicationJSon.name, ApplicationJSon))
   components.push(Vue.component(MenuListPrompt.name, MenuListPrompt))
   components.push(Vue.component(MenuList.name, MenuList))
+  components.push(Vue.component(ReplyCard.name, ReplyCard))
 
   Vue.component(Editable.name, Editable)
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,13 @@ import BlipCardDate from './components/BlipCardDate'
 import ApplicationJSon from './components/ApplicationJSon'
 import MenuListPrompt from './components/ApplicationJSon/MenuListPrompt'
 import MenuList from './components/ApplicationJSon/MenuList'
+
+// Reply components
 import ReplyCard from './components/ReplyCard/ReplyCard'
+import RepliedBase from './components/ReplyCard/Replied/RepliedBase'
+import RepliedWithText from './components/ReplyCard/Replied/RepliedWithText'
+import InReplyToBase from './components/ReplyCard/InReplyTo/InReplyToBase'
+import InReplyToText from './components/ReplyCard/InReplyTo/InReplyToText'
 
 // Validators
 import JsonValidator from './validators/jsonValidator'
@@ -74,7 +80,15 @@ function install(Vue) {
   components.push(Vue.component(ApplicationJSon.name, ApplicationJSon))
   components.push(Vue.component(MenuListPrompt.name, MenuListPrompt))
   components.push(Vue.component(MenuList.name, MenuList))
+
+  // Reply components
   components.push(Vue.component(ReplyCard.name, ReplyCard))
+  // Replied
+  components.push(Vue.component(RepliedBase.name, RepliedBase))
+  components.push(Vue.component(RepliedWithText.name, RepliedWithText))
+  // In Reply To
+  components.push(Vue.component(InReplyToBase.name, InReplyToBase))
+  components.push(Vue.component(InReplyToText.name, InReplyToText))
 
   Vue.component(Editable.name, Editable)
 


### PR DESCRIPTION
Creating the base component for the reply message card and for the reply text or menu with text case.

In order to make the reply message option available we created this structure that can be replicated for other types.

From the lime document example below:

`{
    id: 'b1c3398f-ef63-426d-98b8-37ca84478f8f',
    to: 'to@msging.net',
    from: 'from@msging.net',
    type: 'application/vnd.lime.reply+json',
    content: {
      replied: {
        type: 'text/plain',
        value: 'replied text'
      },
      inReplyTo: {
        id: 'b1c3398f-ef63-426d-98b8-37ca84478f8f',
        type: 'text/plain',
        value: 'in reply to text'
      }
    }
  }`

We can see that we can divide the component in 'replied' and 'inReplyTo' and expand them as new types are developed.

![image](https://github.com/takenet/blip-cards-vue-components/assets/17630459/04d37de7-6755-43cb-83be-171d64ef6fd2)

For the above document example the result is:

![image](https://github.com/takenet/blip-cards-vue-components/assets/17630459/f518509e-af9c-435d-a963-b394ad4a0503)

We also have this behavior when the 'inReplyTo' type is a menu/quick reply component:

![image](https://github.com/takenet/blip-cards-vue-components/assets/17630459/5cb183fe-3358-4344-b6d8-bcf9ee13bb3c)

