### PR TITLE
Atualização de Font-weight dos balões de mensagens para o blip

### DIFF
--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -48,7 +48,7 @@
       max-width: 90%;
       min-width: 160px;
       font-size: 16px;
-      font-weight: 300;
+      font-weight: 400; // Ou remover para retirar o problema de legibilidade dos BlipCards na plataforma
       line-height: 20px;
       white-space: pre-line;
       border: 1px solid $color-content-ghost;


### PR DESCRIPTION
Com a mudança de marca e fonte o peso da fonte está sendo interpretado como light, o que pode gerar um problema de visualização em todos os lugares que utiliza a fonte.

Atualizar o font-weight do bubbles para 400 ou retirar essa regra deixara que o peso seja interpretado pelo blip-ds.

Qualquer coisa me procurem no workchat: Vinicius Rocha