### PR TITLE
fix(BlipCards): fixing audio load in iOS

### DIFF
--- a/src/components/MediaLink/Audio.vue
+++ b/src/components/MediaLink/Audio.vue
@@ -192,7 +192,7 @@ export default {
       this.playbackRate = 1
     },
     initAudio: function(uri) {
-      this.audio = new Audio(uri)
+      this.audio = new Audio()
       this.isLoading = true
       this.audio.addEventListener(
         'canplaythrough',
@@ -202,6 +202,8 @@ export default {
       this.audio.addEventListener('timeupdate', this.audioTimeUpdated)
       this.audio.addEventListener('loadedmetadata', this.audioLoaded)
       this.audio.addEventListener('ended', this.resetPlay)
+      this.audio.src = uri
+      this.audio.load()
     },
     toggleEdit: function() {
       this.isEditing = !this.isEditing


### PR DESCRIPTION
In order to fix an incident related to some iOS users that could not load audio in their chat conversations, we changed how the audio is created and loaded.

Before the changes we created the Audio object with the url that already started to download, now we create an empty Audio object, add to it the necessary event listeners and then update its src and call load manually.