### PR TITLE
fix(ReplyCard): change replied message error logic

### DIFF
--- a/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
+++ b/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
@@ -1,6 +1,7 @@
 <template>
-  <div v-if="isAcceptableTextType || hasFailedToLoad" class="in-reply-to-message-container">
-    <template v-if="isAcceptableTextType">
+  <div v-if="isLoadingMessage || isAcceptableTextType || hasFailedToLoad" class="in-reply-to-message-container">
+    <div v-if="isLoadingMessage" class="skeleton"></div>
+    <template v-else-if="isAcceptableTextType">
       <span class="in-reply-to-message-bar" :class="{ 'own-message': isOwnMessage }"></span>
       <div class="in-reply-to-message">
         <in-reply-to-text
@@ -39,6 +40,10 @@
       failedMessage: {
         type: String,
         default: 'Falha ao carregar mensagem'
+      },
+      loadingMessage: {
+        type: Boolean,
+        default: true
       }
     },
     computed: {
@@ -55,6 +60,12 @@
       isInteractiveTypeListWithTextHeader() {
         return this.inReplyTo.value.interactive.type === 'list' &&
           this.inReplyTo.value.interactive.header.type === 'text'
+      },
+      isLoadingMessage() {
+        setTimeout(() => {
+          this.loadingMessage = false
+        }, 5000)
+        return this.loadingMessage && this.hasFailedToLoad
       },
       isTextPlain() {
         return this.inReplyTo.type === 'text/plain'

--- a/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
+++ b/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
@@ -1,7 +1,6 @@
 <template>
-  <div v-if="isLoadingMessage || isAcceptableTextType || hasFailedToLoad" class="in-reply-to-message-container">
-    <div v-if="isLoadingMessage" class="skeleton"></div>
-    <template v-else-if="isAcceptableTextType">
+  <div v-if="isAcceptableTextType || hasFailedToLoad" class="in-reply-to-message-container">
+    <template v-if="isAcceptableTextType">
       <span class="in-reply-to-message-bar" :class="{ 'own-message': isOwnMessage }"></span>
       <div class="in-reply-to-message">
         <in-reply-to-text
@@ -57,9 +56,6 @@
         return this.inReplyTo.value.interactive.type === 'list' &&
           this.inReplyTo.value.interactive.header.type === 'text'
       },
-      isLoadingMessage() {
-        return this.inReplyTo.type === undefined && this.inReplyTo.failedToLoad === undefined
-      },
       isTextPlain() {
         return this.inReplyTo.type === 'text/plain'
       },
@@ -78,7 +74,7 @@
         return this.isTextPlain || this.isSelectType || this.isAcceptableInteractiveType
       },
       hasFailedToLoad() {
-        return Boolean(this.inReplyTo.failedToLoad)
+        return Boolean(this.inReplyTo.type === undefined || this.inReplyTo.value === undefined)
       }
     }
   }

--- a/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
+++ b/src/components/ReplyCard/InReplyTo/InReplyToBase.vue
@@ -1,7 +1,6 @@
 <template>
-  <div v-if="isLoadingMessage || isAcceptableTextType || hasFailedToLoad" class="in-reply-to-message-container">
-    <div v-if="isLoadingMessage" class="skeleton"></div>
-    <template v-else-if="isAcceptableTextType">
+  <div v-if="isAcceptableTextType || hasFailedToLoad" class="in-reply-to-message-container">
+    <template v-if="isAcceptableTextType">
       <span class="in-reply-to-message-bar" :class="{ 'own-message': isOwnMessage }"></span>
       <div class="in-reply-to-message">
         <in-reply-to-text
@@ -40,10 +39,6 @@
       failedMessage: {
         type: String,
         default: 'Falha ao carregar mensagem'
-      },
-      loadingMessage: {
-        type: Boolean,
-        default: true
       }
     },
     computed: {
@@ -60,12 +55,6 @@
       isInteractiveTypeListWithTextHeader() {
         return this.inReplyTo.value.interactive.type === 'list' &&
           this.inReplyTo.value.interactive.header.type === 'text'
-      },
-      isLoadingMessage() {
-        setTimeout(() => {
-          this.loadingMessage = false
-        }, 5000)
-        return this.loadingMessage && this.hasFailedToLoad
       },
       isTextPlain() {
         return this.inReplyTo.type === 'text/plain'


### PR DESCRIPTION
Changing logic to show Error message on replied card message. The value will consider if the value or type does not has value to show error. The 'failedToLoad' field will no longer be informed.