### PR TITLE
fix(Video): Fixing iOS video loading events

### DIFF
--- a/src/components/MediaLink/Video.vue
+++ b/src/components/MediaLink/Video.vue
@@ -19,7 +19,7 @@
           <div class="sk-circle-wrapper" id="animation">
             <bds-loading-spinner size="small" color="main"></bds-loading-spinner>
           </div>
-          <video :src="videoUri" id="blipVideo"></video>
+          <video id="blipVideo"></video>
         </div>
         <div class="video-player-controls" id="videoPlayerControls">
           <span v-if="isPlaying" @click="togglePlay">
@@ -181,9 +181,6 @@ export default {
     this.video.removeEventListener('ended', this.resetPlay)
     this.asyncFetchMedia && URL.revokeObjectURL(this.videoUri)
   },
-  updated: function() {
-    this.initVideo()
-  },
   methods: {
     init: async function() {
       this.videoUri = isAuthenticatedMediaLink(this.document)
@@ -241,6 +238,10 @@ export default {
       this.video.addEventListener('seeked', this.readyToPlay)
       this.video.addEventListener('canplay', this.readyToPlay)
       this.video.addEventListener('ended', this.resetPlay)
+
+      this.video.src = this.videoUri
+
+      this.video.load()
     },
     toggleEdit: function() {
       this.isEditing = !this.isEditing
@@ -270,12 +271,13 @@ export default {
       })
     },
     togglePlay: function() {
-      this.isPlaying = !this.isPlaying
       if (this.isPlaying) {
-        this.video.play()
-      } else {
         this.video.pause()
+      } else {
+        this.video.play()
       }
+
+      this.isPlaying = !this.isPlaying
     },
     resetPlay: function() {
       if (this.isPlaying && (this.video.currentTime = this.totalTime)) {
@@ -300,7 +302,6 @@ export default {
     },
     videoLoaded: function() {
       this.totalTime = this.video.duration
-      this.$emit('updated')
     },
     setVideoPosition: function(event) {
       // srcElement is no supported in FF, but needed if working with IE6-8


### PR DESCRIPTION
Videos loaded in iOS were loaded but the loading animation never stopped because it could not listen in time to events

fix #541785

--------

Before the changes

![image](https://github.com/takenet/blip-cards-vue-components/assets/17630459/5cbc7f50-beae-45ec-95c8-03ecfc17eaa1)

After the changes

![image](https://github.com/takenet/blip-cards-vue-components/assets/17630459/d8182e10-5ab6-4fd2-a141-8fad3c346fed)

![image](https://github.com/takenet/blip-cards-vue-components/assets/17630459/a6b5c988-a544-43cc-9d3b-436a071e5c88)

Now in chrome on Windows kept working as usual

![image](https://github.com/takenet/blip-cards-vue-components/assets/17630459/f174fb8f-734d-4047-9fcf-16e5454d2a25)

