### PR TITLE
Fixing authenticated video loading

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -476,7 +476,7 @@ export default {
         content: {
           type: 'video/mp4',
           uri:
-            'https://sample-videos.com/video123/mp4/720/big_buck_bunny_720p_1mb.mp4',
+            'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
           size: '1'
         }
       })

--- a/src/App.vue
+++ b/src/App.vue
@@ -476,7 +476,7 @@ export default {
         content: {
           type: 'video/mp4',
           uri:
-            'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+            'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4',
           size: '1'
         }
       })

--- a/src/components/MediaLink/Video.vue
+++ b/src/components/MediaLink/Video.vue
@@ -203,8 +203,6 @@ export default {
         ? await tryCreateLocalMediaUri(this.document, this.asyncFetchMedia)
         : this.document.uri
 
-      this.video = this.$el.querySelector('#blipVideo')
-
       if (!this.video) {
         this.video = this.$el.querySelector('#blipVideo')
       }

--- a/src/components/MediaLink/Video.vue
+++ b/src/components/MediaLink/Video.vue
@@ -182,10 +182,8 @@ export default {
     this.asyncFetchMedia && URL.revokeObjectURL(this.videoUri)
   },
   methods: {
-    init: async function() {
-      this.videoUri = isAuthenticatedMediaLink(this.document)
-        ? await tryCreateLocalMediaUri(this.document, this.asyncFetchMedia)
-        : this.document.uri
+    init: function() {
+      this.videoUri = undefined
       this.text = this.document.text
       this.isPlaying = false
       this.isFullScreen = false
@@ -200,7 +198,13 @@ export default {
       this.inactivityTimeout = undefined
       this.animation = undefined
     },
-    initVideo: function() {
+    initVideo: async function() {
+      this.videoUri = isAuthenticatedMediaLink(this.document)
+        ? await tryCreateLocalMediaUri(this.document, this.asyncFetchMedia)
+        : this.document.uri
+
+      this.video = this.$el.querySelector('#blipVideo')
+
       if (!this.video) {
         this.video = this.$el.querySelector('#blipVideo')
       }

--- a/src/utils/media.js
+++ b/src/utils/media.js
@@ -5,6 +5,11 @@ export async function tryCreateLocalMediaUri(mediaDocument, asyncFetchMedia) {
     const localUri = URL.createObjectURL(
       new Blob([await result.arrayBuffer()], { type: mediaDocument.type })
     )
+
+    if (!localUri) {
+      return uri
+    }
+
     return localUri
   } catch (error) {
     return uri


### PR DESCRIPTION
With the previous change we added a side effect that caused authenticated videos to not be loaded properly in blip-chat.

In order to fix it and keep the video working on iOS we changed where the video url is obtained. First it was during the init method  of the component, but that caused the url to be undefined sometimes, now it is on the same method we load the video.

---------

blip-cards

![image](https://github.com/takenet/blip-cards-vue-components/assets/17630459/457fbc15-43e9-4606-91bd-4aa9104eee3e)

blip-desk

![image](https://github.com/takenet/blip-cards-vue-components/assets/17630459/f481aba5-2749-4170-a152-c81f250bf4b8)

![image](https://github.com/takenet/blip-cards-vue-components/assets/17630459/e8845efa-f624-4153-b98d-a81f2e5b90d6)

blip-chat

![image](https://github.com/takenet/blip-cards-vue-components/assets/17630459/f766d0f2-ee10-4a3b-9587-908fd3e8171d)

![image](https://github.com/takenet/blip-cards-vue-components/assets/17630459/8ceafefb-7826-4aa0-a15e-71faf9fcd339)
