### PR TITLE
fix(BlipCard.vue): blip calls translation message

### DIFF
--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -342,7 +342,7 @@
           :voice-call-msg="translations.voiceCallMsg"
           :success-status-msg="translations.successStatusMsg"
           :failed-status-msg="translations.failedStatusMsg"
-          :cancel-status-msg="ctranslations.cancelStatusMsg"
+          :cancel-status-msg="translations.cancelStatusMsg"
           :not-answered-status-msg="translations.notAnsweredStatusMsg"
           :status="status"
           :position="position"


### PR DESCRIPTION
- Fixed blip calls translation "cancelStatusMsg"