### PR TITLE
Fix the word wrap inside the bubble

### DIFF
--- a/src/commandExamples.js
+++ b/src/commandExamples.js
@@ -1182,7 +1182,7 @@ export const commandExamples = [
           components: [
             {
               type: 'BODY',
-              text: 'Olá Usuário!\n\nCompre castanha de caju direto da fábrica!\nSomos o parceiro que faltava no fornecimento de castanha de caju orgânica de qualidade para o seu negócio.\n\n_Esta podendo falar?_\n\nhttps://url-link.com/p/ifCeg3.mp4'
+              text: 'Olá Usuário!\n\nCompre castanha de caju direto da fábrica!\nSomos o parceiro que faltava no fornecimento de castanha de caju orgânica de qualidade para o seu negócio.\n\n_Esta podendo falar?_\n\nhttps://url-link.com/p/ifCeg3/p/ifCeg3/p/ifCeg3/p/ifCeg3/p/ifCeg3/p/ifCeg3/p/ifCeg3/p/ifCeg3/p/ifCeg3/p/ifCeg3.mp4'
             }
           ]
         }

--- a/src/components/TemplateContent/TemplateContent.vue
+++ b/src/components/TemplateContent/TemplateContent.vue
@@ -2,7 +2,7 @@
   <div class="blip-container">
     <bds-grid direction="column" :align-items="position === 'right' ? 'flex-end' : 'flex-start'">
       <div :class="bubbleClass">
-        <bds-grid direction="column" padding="x-2">
+        <bds-grid direction="column" padding="x-2" class="wrap">
           <bds-grid direction="row" justify-content="flex-start" padding="y-1" gap="1">
             <bds-icon v-if="position === 'right'" size="small" color="white" alt="paperplane" name="paperplane" />
             <bds-icon v-else size="small" alt="paperplane" name="paperplane" />
@@ -197,6 +197,10 @@ $template-width: 368px;
 
   &.template-width {
     width: $template-width;
+  }
+
+  > .wrap {
+    overflow-wrap: anywhere;
   }
 }
 

--- a/src/components/TemplateContent/TemplateContent.vue
+++ b/src/components/TemplateContent/TemplateContent.vue
@@ -97,7 +97,6 @@ export default {
   },
   created() {
     this.componentButtons = parseComponentButtons(this.document)
-    console.log(this.componentButtons)
   },
   computed: {
     showTemplateContentTitle() {


### PR DESCRIPTION
This PR is about fixing the word wrap inside the template content surrounded by the .bubble CSS class.
I'm removing an unnecessary console.log.

Before:
![image](https://github.com/takenet/blip-cards-vue-components/assets/2117093/7dcad065-10ba-47f8-8ad9-5b79de3516ff)

After:
![image](https://github.com/takenet/blip-cards-vue-components/assets/2117093/c0e0b4c1-fd48-40c1-9239-a3948c12d1f8)
