### PR TITLE
fix: Template message - White spaces fix

### DIFF
--- a/src/components/TemplateContent/MediaContent/MediaContent.vue
+++ b/src/components/TemplateContent/MediaContent/MediaContent.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="'blip-container media-link ' + mediaType + isFailedMessage(status, position)"
     id="blip-container">
-    <div id='media-content'>
+    <div id='media-content' class="media-content">
       <blip-image
         :image-uri-msg="titleMsg"
         :title-msg="titleMsg"
@@ -115,6 +115,10 @@ export default {
 
 <style lang="scss">
 @import '../../../styles/variables.scss';
+
+.media-content {
+  white-space: normal;
+}
 
 .padding-control {
   padding: $bubble-padding;


### PR DESCRIPTION
Image:
Before:
![image](https://github.com/takenet/blip-cards-vue-components/assets/85000889/4da4e613-4c24-4ac3-b4b0-b412b486da6b)

After:
![image](https://github.com/takenet/blip-cards-vue-components/assets/85000889/85d5f672-b559-4681-8c8f-19105047bee7)
