### PR TITLE
#649293 - Identify external messages in blip cards

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -42,6 +42,8 @@
       <input type="checkbox" value="false" v-model="photo" /> Show Photo
       <br />
       <input type="checkbox" value="false" v-model="group" /> Group Messages
+      <br />
+      <input type="checkbox" value="false" v-model="isExternalMessage" /> External Message
 
       <div>
         <h1>Status notification:</h1>
@@ -318,6 +320,12 @@ export default {
     onScroll: function(e) {},
     send: function() {
       const doc = JSON.parse(this.json)
+      if (this.isExternalMessage) {
+        doc.metadata = {
+          ...doc.metadata,
+          '#messageEmitter': 'externalMessages'
+        }
+      }
       this.documents.push({
         document: doc,
         date: this.date,
@@ -1677,7 +1685,8 @@ export default {
       readonly: false,
       translations: {
         failedToSend: 'Falha ao enviar a mensagem.'
-      }
+      },
+      isExternalMessage: false
     }
   },
   components: {}

--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -124,6 +124,8 @@
           :deletable="deletable"
           :editing="isCardEditing"
           :on-cancel="cancel"
+          :is-external-message="checkIsExternalMessage(document)"
+          :external-message-text="translations.externalMessageText"
         />
 
         <collection

--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -411,6 +411,8 @@
           :deletable="deletable"
           :editing="isCardEditing"
           :on-cancel="cancel"
+          :is-external-message="checkIsExternalMessage(document)"
+          :external-message-text="translations.externalMessageText"
         />
 
         <contact

--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -237,6 +237,8 @@
           :deletable="deletable"
           :editing="isCardEditing"
           :on-cancel="cancel"
+          :is-external-message="checkIsExternalMessage(document)"
+          :external-message-text="translations.externalMessageText"
         />
 
         <request-location

--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -84,6 +84,8 @@
           :on-cancel="cancel"
           :on-audio-validate-uri="onAudioValidateUri"
           :async-fetch-media="asyncFetchMedia"
+          :is-external-message="checkIsExternalMessage(document)"
+          :external-message-text="translations.externalMessageText"
         />
 
         <document-select

--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -195,6 +195,8 @@
           :deletable="deletable"
           :editing="isCardEditing"
           :on-cancel="cancel"
+          :is-external-message="checkIsExternalMessage(document)"
+          :external-message-text="translations.externalMessageText"
         />
 
         <survey

--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -124,8 +124,6 @@
           :deletable="deletable"
           :editing="isCardEditing"
           :on-cancel="cancel"
-          :is-external-message="checkIsExternalMessage(document)"
-          :external-message-text="translations.externalMessageText"
         />
 
         <collection

--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -440,6 +440,8 @@
           :phone-label="translations.phoneLabel"
           :mail-label="translations.mailLabel"
           :address-label="translations.addressLabel"
+          :is-external-message="checkIsExternalMessage(document)"
+          :external-message-text="translations.externalMessageText"
         />
 
         <application-json

--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -30,6 +30,8 @@
           :deletable="deletable"
           :editing="isCardEditing"
           :on-cancel="cancel"
+          :is-external-message="checkIsExternalMessage"
+          :external-message-text="translations.externalMessageText"
         />
 
         <plain-text
@@ -51,6 +53,8 @@
           :editing="isCardEditing"
           :on-cancel="cancel"
           :disable-link="disableLink"
+          :is-external-message="checkIsExternalMessage"
+          :external-message-text="translations.externalMessageText"
         />
 
         <media-link
@@ -753,6 +757,9 @@ export default {
   computed: {
     MessageTypesConstants() {
       return MessageTypesConstants
+    },
+    checkIsExternalMessage() {
+      return this.document && this.document.metadata && this.document.metadata['#messageEmitter'] === 'externalMessages'
     }
   }
 }

--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -30,7 +30,7 @@
           :deletable="deletable"
           :editing="isCardEditing"
           :on-cancel="cancel"
-          :is-external-message="checkIsExternalMessage(document)"
+          :is-external-message="externalMessage"
           :external-message-text="translations.externalMessageText"
         />
 
@@ -53,7 +53,7 @@
           :editing="isCardEditing"
           :on-cancel="cancel"
           :disable-link="disableLink"
-          :is-external-message="checkIsExternalMessage(document)"
+          :is-external-message="externalMessage"
           :external-message-text="translations.externalMessageText"
         />
 
@@ -84,7 +84,7 @@
           :on-cancel="cancel"
           :on-audio-validate-uri="onAudioValidateUri"
           :async-fetch-media="asyncFetchMedia"
-          :is-external-message="checkIsExternalMessage(document)"
+          :is-external-message="externalMessage"
           :external-message-text="translations.externalMessageText"
         />
 
@@ -197,7 +197,7 @@
           :deletable="deletable"
           :editing="isCardEditing"
           :on-cancel="cancel"
-          :is-external-message="checkIsExternalMessage(document)"
+          :is-external-message="externalMessage"
           :external-message-text="translations.externalMessageText"
         />
 
@@ -237,7 +237,7 @@
           :deletable="deletable"
           :editing="isCardEditing"
           :on-cancel="cancel"
-          :is-external-message="checkIsExternalMessage(document)"
+          :is-external-message="externalMessage"
           :external-message-text="translations.externalMessageText"
         />
 
@@ -415,7 +415,7 @@
           :deletable="deletable"
           :editing="isCardEditing"
           :on-cancel="cancel"
-          :is-external-message="checkIsExternalMessage(document)"
+          :is-external-message="externalMessage"
           :external-message-text="translations.externalMessageText"
         />
 
@@ -438,7 +438,7 @@
           :phone-label="translations.phoneLabel"
           :mail-label="translations.mailLabel"
           :address-label="translations.addressLabel"
-          :is-external-message="checkIsExternalMessage(document)"
+          :is-external-message="externalMessage"
           :external-message-text="translations.externalMessageText"
         />
 
@@ -491,7 +491,7 @@
           :video-uri-msg="translations.videoUri"
           :on-audio-validate-uri="onAudioValidateUri"
           :reply-text="translations.replyText"
-          :is-external-message="checkIsExternalMessage(document)"
+          :is-external-message="externalMessage"
           :external-message-text="translations.externalMessageText"
         />
 
@@ -525,7 +525,7 @@
           :on-audio-validate-uri="onAudioValidateUri"
           :reaction-text="translations.reactionText"
           :removed-reaction-text="translations.removedReactionText"
-          :is-external-message="checkIsExternalMessage(document)"
+          :is-external-message="externalMessage"
           :external-message-text="translations.externalMessageText"
         />
 
@@ -682,8 +682,7 @@ export default {
     return {
       editableDocument: this.document,
       isCardEditing: this.editing,
-      photoMargin: 0,
-      checkIsExternalMessage
+      photoMargin: 0
     }
   },
   watch: {
@@ -773,6 +772,9 @@ export default {
   computed: {
     MessageTypesConstants() {
       return MessageTypesConstants
+    },
+    externalMessage() {
+      return checkIsExternalMessage(this.document)
     }
   }
 }

--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -30,7 +30,7 @@
           :deletable="deletable"
           :editing="isCardEditing"
           :on-cancel="cancel"
-          :is-external-message="checkIsExternalMessage"
+          :is-external-message="checkIsExternalMessage(document)"
           :external-message-text="translations.externalMessageText"
         />
 
@@ -53,7 +53,7 @@
           :editing="isCardEditing"
           :on-cancel="cancel"
           :disable-link="disableLink"
-          :is-external-message="checkIsExternalMessage"
+          :is-external-message="checkIsExternalMessage(document)"
           :external-message-text="translations.externalMessageText"
         />
 
@@ -601,6 +601,7 @@
 <script>
 import { default as base } from '../mixins/baseComponent.js'
 import { MessageTypesConstants } from '../utils/MessageTypesConstants.js'
+import { checkIsExternalMessage } from '../utils/externalMessages.js'
 
 const supportedRepliedTypes = [
   MessageTypesConstants.TEXT_MESSAGE,
@@ -667,7 +668,8 @@ export default {
     return {
       editableDocument: this.document,
       isCardEditing: this.editing,
-      photoMargin: 0
+      photoMargin: 0,
+      checkIsExternalMessage
     }
   },
   watch: {
@@ -757,9 +759,6 @@ export default {
   computed: {
     MessageTypesConstants() {
       return MessageTypesConstants
-    },
-    checkIsExternalMessage() {
-      return this.document && this.document.metadata && this.document.metadata['#messageEmitter'] === 'externalMessages'
     }
   }
 }

--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -491,6 +491,8 @@
           :video-uri-msg="translations.videoUri"
           :on-audio-validate-uri="onAudioValidateUri"
           :reply-text="translations.replyText"
+          :is-external-message="checkIsExternalMessage(document)"
+          :external-message-text="translations.externalMessageText"
         />
 
         <reaction-card

--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -525,6 +525,8 @@
           :on-audio-validate-uri="onAudioValidateUri"
           :reaction-text="translations.reactionText"
           :removed-reaction-text="translations.removedReactionText"
+          :is-external-message="checkIsExternalMessage(document)"
+          :external-message-text="translations.externalMessageText"
         />
 
         <copy-and-paste-card

--- a/src/components/BlipCardDate.vue
+++ b/src/components/BlipCardDate.vue
@@ -8,6 +8,7 @@
       v-else-if="this.status === 'failed' && this.position === 'right'"
       class="failure"
     >
+      <img v-if="this.showAlertIcon" :src="alertSvg" draggable="false"/>
       {{ failedToSendMsg }}
     </div>
     {{ isExternalMessage ? externalMessageText + ' | ' + date : date }}
@@ -19,6 +20,7 @@ import checkSentSvg from '../assets/img/CheckSent.svg'
 import clockSvg from '../assets/img/clock.svg'
 import doubleCheckReceivedSvg from '../assets/img/DoubleCheckReceived.svg'
 import doubleCheckReadSvg from '../assets/img/DoubleCheckRead.svg'
+import alertSvg from '../assets/img/alert.svg'
 
 export default {
   name: 'blip-card-date',
@@ -49,6 +51,15 @@ export default {
     isGroup: {
       type: Boolean,
       default: false
+    },
+    showAlertIcon: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data: function() {
+    return {
+      alertSvg
     }
   },
   computed: {

--- a/src/components/BlipCardDate.vue
+++ b/src/components/BlipCardDate.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex" :class="'notification ' + position" v-if="date">
+  <div class="flex" :class="`${isGroup ? 'group-' : ''}notification ` + position" v-if="date">
     <img
       v-if="this.status !== 'failed' && this.position === 'right'"
       :src="this.getImage"
@@ -45,6 +45,10 @@ export default {
     externalMessageText: {
       type: String,
       default: 'Enviada pelo aplicativo'
+    },
+    isGroup: {
+      type: Boolean,
+      default: false
     }
   },
   computed: {

--- a/src/components/BlipCardDate.vue
+++ b/src/components/BlipCardDate.vue
@@ -13,6 +13,9 @@
     </div>
     {{ isExternalMessage ? externalMessageText + ' | ' + date : date }}
   </div>
+  <div class="flex" :class="`${isGroup ? 'group-' : ''}notification ` + position" v-else>
+    <img v-if="this.status === 'dispatched' && this.position === 'right'" :src="clockSvg" draggable="false">
+  </div>
 </template>
 
 <script>
@@ -59,7 +62,8 @@ export default {
   },
   data: function() {
     return {
-      alertSvg
+      alertSvg,
+      clockSvg
     }
   },
   computed: {

--- a/src/components/BlipCardDate.vue
+++ b/src/components/BlipCardDate.vue
@@ -9,7 +9,7 @@
       class="failure"
     >
       <img v-if="this.showAlertIcon" :src="alertSvg" draggable="false"/>
-      {{ failedToSendMsg }}
+      {{ showAlertIcon ? '' : failedToSendMsg }}
     </div>
     {{ isExternalMessage ? externalMessageText + ' | ' + date : date }}
   </div>

--- a/src/components/BlipCardDate.vue
+++ b/src/components/BlipCardDate.vue
@@ -10,7 +10,7 @@
     >
       {{ failedToSendMsg }}
     </div>
-    {{ date }}
+    {{ isExternalMessage ? externalMessageText + ' | ' + date : date }}
   </div>
 </template>
 
@@ -37,6 +37,14 @@ export default {
     failedToSendMsg: {
       type: String,
       default: 'Falha ao enviar a mensagem.'
+    },
+    isExternalMessage: {
+      type: Boolean,
+      default: false
+    },
+    externalMessageText: {
+      type: String,
+      default: 'Enviada pelo aplicativo'
     }
   },
   computed: {

--- a/src/components/BlipGroupCard.vue
+++ b/src/components/BlipGroupCard.vue
@@ -41,6 +41,7 @@
           :is-external-message="checkIsExternalMessage(group.msgs[0].document)"
           :external-message-text="externalMessageText"
           :is-group="true"
+          :show-alert-icon="Boolean(onFailedClickIcon)"
         />
       </div>
       <span v-if="onFailedClickIcon && group.status === 'failed'">

--- a/src/components/BlipGroupCard.vue
+++ b/src/components/BlipGroupCard.vue
@@ -159,26 +159,26 @@ export default {
         status: this.documents[0].status
       }
       for (let i = 1; i < this.documents.length; i++) {
-        const message1 = group.msgs[group.msgs.length - 1]
-        const message2 = this.documents[i]
-        const isMessage1External = checkIsExternalMessage(message1.document)
-        const isMessage2External = checkIsExternalMessage(message2.document)
-        if (this.compareMessages(message1, message2) && (isMessage1External === isMessage2External)) {
-          group.msgs.push(message2)
-          group.date = message2.date
-          group.status = message2.status
-          group.reason = message2.reason
+        const lastMessage = group.msgs[group.msgs.length - 1]
+        const currentMessage = this.documents[i]
+        const isLastMessageExternal = checkIsExternalMessage(lastMessage.document)
+        const isCurrentMessageExternal = checkIsExternalMessage(currentMessage.document)
+        if (this.compareMessages(lastMessage, currentMessage) && (isLastMessageExternal === isCurrentMessageExternal)) {
+          group.msgs.push(currentMessage)
+          group.date = currentMessage.date
+          group.status = currentMessage.status
+          group.reason = currentMessage.reason
         } else {
           groups.push(group)
 
           group = {
-            msgs: [message2],
-            position: message2.position,
-            photo: message2.photo,
-            date: message2.date,
-            hasNotification: this.showNotification(message2),
-            status: message2.status,
-            reason: message2.reason
+            msgs: [currentMessage],
+            position: currentMessage.position,
+            photo: currentMessage.photo,
+            date: currentMessage.date,
+            hasNotification: this.showNotification(currentMessage),
+            status: currentMessage.status,
+            reason: currentMessage.reason
           }
         }
       }

--- a/src/components/BlipSelect.vue
+++ b/src/components/BlipSelect.vue
@@ -76,16 +76,12 @@
         </div>
       </div>
 
-      <div class="flex" :class="'notification ' + position" v-if="date">
-        <img v-if="this.status === 'waiting' && this.position === 'right'" :src="clockSvg">
-        <img v-else-if="status === 'accepted' && this.position === 'right'" :src="checkSentSvg"/>
-        <img v-else-if="status === 'received' && this.position === 'right'" :src="doubleCheckReceivedSvg"/>
-        <img v-else-if="status === 'consumed' && this.position === 'right'" :src="doubleCheckReadSvg"/>
-        <div v-else-if="this.status === 'failed' && this.position === 'right'" class="failure" >
-          {{ failedToSendMsg }}
-        </div>
-        {{ date }}
-      </div>
+      <blip-card-date
+        :status="status"
+        :position="position"
+        :date="date"
+        :failed-to-send-msg="failedToSendMsg"
+      />
     </div>
   </div>
 

--- a/src/components/Collection.vue
+++ b/src/components/Collection.vue
@@ -26,16 +26,12 @@
         <span class="next" v-if="showNext" @click="plusSlides(1)">&#10095;</span>
       </div>
 
-      <div class="flex" :class="'notification ' + position" v-if="date">
-        <img v-if="this.status === 'waiting' && this.position === 'right'" :src="clockSvg">
-        <img v-else-if="status === 'accepted' && this.position === 'right'" :src="checkSentSvg"/>
-        <img v-else-if="status === 'received' && this.position === 'right'" :src="doubleCheckReceivedSvg"/>
-        <img v-else-if="status === 'consumed' && this.position === 'right'" :src="doubleCheckReadSvg"/>
-        <div class="failure" v-else-if="this.status === 'failed' && this.position === 'right'">
-          {{ failedToSendMsg }}
-        </div>
-        {{ date }}
-      </div>
+      <blip-card-date
+        :status="status"
+        :position="position"
+        :date="date"
+        :failed-to-send-msg="failedToSendMsg"
+      />
     </div>
 
     <div v-else-if="document.itemType === 'application/vnd.lime.container+json'">

--- a/src/components/Contact.vue
+++ b/src/components/Contact.vue
@@ -32,26 +32,14 @@
         </div>
       </div>
 
-      <div class="flex" :class="'notification ' + position" v-if="date">
-        <img v-if="this.status === 'waiting' && this.position === 'right'" :src="clockSvg">
-        <img
-          v-else-if="this.status === 'accepted' && this.position === 'right'"
-          :src="checkSentSvg"
-        >
-        <img
-          v-else-if="this.status === 'received' && this.position === 'right'"
-          :src="doubleCheckReceivedSvg"
-        >
-        <img
-          v-else-if="this.status === 'consumed' && this.position === 'right'"
-          :src="doubleCheckReadSvg"
-        >
-        <div
-          v-else-if="this.status === 'failed' && this.position === 'right'"
-          class="failure"
-        >{{ failedToSendMsg }}</div>
-        <div>{{ date }}</div>
-      </div>
+      <blip-card-date
+        :status="status"
+        :position="position"
+        :date="date"
+        :failed-to-send-msg="failedToSendMsg"
+        :is-external-message="isExternalMessage"
+        :external-message-text="externalMessageText"
+      />
     </div>
   </div>
 

--- a/src/components/DocumentSelect.vue
+++ b/src/components/DocumentSelect.vue
@@ -68,20 +68,14 @@
       </div>
     </div>
 
-    <div class="flex" :class="'notification ' + position" v-if="date">
-      <img v-if="this.status === 'waiting' && this.position === 'right'" :src="clockSvg">
-      <img v-else-if="status === 'accepted' && this.position === 'right'" :src="checkSentSvg">
-      <img
-        v-else-if="status === 'received' && this.position === 'right'"
-        :src="doubleCheckReceivedSvg"
-      >
-      <img v-else-if="status === 'consumed' && this.position === 'right'" :src="doubleCheckReadSvg">
-      <div
-        class="failure"
-        v-else-if="this.status === 'failed' && this.position === 'right'"
-      >{{ failedToSendMsg }}</div>
-      {{ date }}
-    </div>
+    <blip-card-date
+      :status="status"
+      :position="position"
+      :date="date"
+      :failed-to-send-msg="failedToSendMsg"
+      :is-external-message="isExternalMessage"
+      :external-message-text="externalMessageText"
+    />
   </div>
 
   <div v-else class="blip-container document-select">

--- a/src/components/DocumentSelect.vue
+++ b/src/components/DocumentSelect.vue
@@ -73,8 +73,6 @@
       :position="position"
       :date="date"
       :failed-to-send-msg="failedToSendMsg"
-      :is-external-message="isExternalMessage"
-      :external-message-text="externalMessageText"
     />
   </div>
 

--- a/src/components/Location.vue
+++ b/src/components/Location.vue
@@ -45,20 +45,14 @@
         </div>
       </div>
     </div>
-    <div class="flex" :class="'notification ' + position" v-if="date">
-      <img v-if="this.status === 'waiting' && this.position === 'right'" :src="clockSvg">
-      <img v-else-if="status === 'accepted' && this.position === 'right'" :src="checkSentSvg">
-      <img
-        v-else-if="status === 'received' && this.position === 'right'"
-        :src="doubleCheckReceivedSvg"
-      >
-      <img v-else-if="status === 'consumed' && this.position === 'right'" :src="doubleCheckReadSvg">
-      <div
-        class="failure"
-        v-else-if="this.status === 'failed' && this.position === 'right'"
-      >{{ failedToSendMsg }}</div>
-      {{ date }}
-    </div>
+    <blip-card-date
+      :status="status"
+      :position="position"
+      :date="date"
+      :failed-to-send-msg="failedToSendMsg"
+      :is-external-message="isExternalMessage"
+      :external-message-text="externalMessageText"
+    />
   </div>
   <div v-else class="blip-container location">
     <form :class="'editing bubble ' + position" novalidate v-on:submit.prevent>

--- a/src/components/MediaLink.vue
+++ b/src/components/MediaLink.vue
@@ -92,16 +92,14 @@
         :async-fetch-media="asyncFetchMedia"/>
 
     </div>
-    <div class="flex" :class="'notification ' + position" v-if="date">
-      <img v-if="this.status === 'waiting' && this.position === 'right'" :src="clockSvg">
-      <img v-else-if="status === 'accepted' && this.position === 'right'" :src="checkSentSvg"/>
-      <img v-else-if="status === 'received' && this.position === 'right'" :src="doubleCheckReceivedSvg"/>
-      <img v-else-if="status === 'consumed' && this.position === 'right'" :src="doubleCheckReadSvg"/>
-      <div v-else-if="this.status === 'failed' && this.position === 'right'" class="failure">
-          {{ failedToSendMsg }}
-        </div>
-      {{ date }}
-      </div>
+    <blip-card-date
+      :status="status"
+      :position="position"
+      :date="date"
+      :failed-to-send-msg="failedToSendMsg"
+      :is-external-message="isExternalMessage"
+      :external-message-text="externalMessageText"
+    />
   </div>
 </template>
 

--- a/src/components/PlainText.vue
+++ b/src/components/PlainText.vue
@@ -29,27 +29,14 @@
           <a style="display: block;" v-show="!showContent" v-on:click="showContent = true">{{ showMoreMsg }}</a>
         </div>
       </div>
-
-      <div class="flex" :class="'notification ' + position" v-if="date">
-        <img v-if="this.status === 'waiting' && this.position === 'right'" :src="clockSvg">
-        <img
-          v-else-if="this.status === 'accepted' && this.position === 'right'"
-          :src="checkSentSvg"
-        >
-        <img
-          v-else-if="this.status === 'received' && this.position === 'right'"
-          :src="doubleCheckReceivedSvg"
-        >
-        <img
-          v-else-if="this.status === 'consumed' && this.position === 'right'"
-          :src="doubleCheckReadSvg"
-        >
-        <div
-          v-else-if="this.status === 'failed' && this.position === 'right'"
-          class="failure"
-        >{{ failedToSendMsg }}</div>
-        <div>{{ date }}</div>
-      </div>
+      <blip-card-date
+        :status="status"
+        :position="position"
+        :date="date"
+        :failed-to-send-msg="failedToSendMsg"
+        :is-external-message="isExternalMessage"
+        :external-message-text="externalMessageText"
+      />
     </div>
   </div>
 

--- a/src/components/ReactionCard/ReactionCard.vue
+++ b/src/components/ReactionCard/ReactionCard.vue
@@ -32,7 +32,10 @@
         :status="status"
         :position="position"
         :date="date"
-        :failed-to-send-msg="failedToSendMsg" />
+        :failed-to-send-msg="failedToSendMsg"
+        :is-external-message="isExternalMessage"
+        :external-message-text="externalMessageText"
+      />
     </div>
   </template>
   

--- a/src/components/ReplyCard/ReplyCard.vue
+++ b/src/components/ReplyCard/ReplyCard.vue
@@ -39,7 +39,10 @@
       :status="status"
       :position="position"
       :date="date"
-      :failed-to-send-msg="failedToSendMsg" />
+      :failed-to-send-msg="failedToSendMsg"
+      :is-external-message="isExternalMessage"
+      :external-message-text="externalMessageText"
+    />
   </div>
 </template>
 

--- a/src/components/UnsuportedContent.vue
+++ b/src/components/UnsuportedContent.vue
@@ -15,18 +15,14 @@
         aria-label="Active message failed reason" 
         class="icon-active-message-failed" 
         @click="onFailedClickIcon(fullDocument)"></bds-icon>
-    <div class="flex" :class="'notification ' + position" v-if="date">
-      <span v-if="this.position === 'right'">
-        <img v-if="this.status === 'waiting'" :src="clockSvg">
-        <img v-else-if="this.status === 'accepted'" :src="checkSentSvg">
-        <img v-else-if="this.status === 'received'" :src="doubleCheckReceivedSvg">
-        <img v-else-if="this.status === 'consumed'" :src="doubleCheckReadSvg">
-        <div v-else-if="this.status === 'failed'" class="failure">
-          {{ failedToSendMsg }}
-        </div>
-      </span>
-      <div>{{ date }}</div>
-    </div>
+    <blip-card-date
+      :status="status"
+      :position="position"
+      :date="date"
+      :failed-to-send-msg="failedToSendMsg"
+      :is-external-message="isExternalMessage"
+      :external-message-text="externalMessageText"
+    />
   </div>
 </template>
 

--- a/src/components/WebLink.vue
+++ b/src/components/WebLink.vue
@@ -46,20 +46,14 @@
         <span v-else v-html="sanitize(this.textLink)"></span>
       </div>
     </div>
-    <div class="flex" :class="'notification ' + position" v-if="date">
-      <img v-if="this.status === 'waiting' && this.position === 'right'" :src="clockSvg">
-      <img v-else-if="status === 'accepted' && this.position === 'right'" :src="checkSentSvg">
-      <img
-        v-else-if="status === 'received' && this.position === 'right'"
-        :src="doubleCheckReceivedSvg"
-      >
-      <img v-else-if="status === 'consumed' && this.position === 'right'" :src="doubleCheckReadSvg">
-      <div
-        v-else-if="this.status === 'failed' && this.position === 'right'"
-        class="failure"
-      >{{ failedToSendMsg }}</div>
-      {{ date }}
-    </div>
+    <blip-card-date
+        :status="status"
+        :position="position"
+        :date="date"
+        :failed-to-send-msg="failedToSendMsg"
+        :is-external-message="isExternalMessage"
+        :external-message-text="externalMessageText"
+      />
   </div>
   <div v-else class="blip-container web-link">
     <form :class="'bubble ' + position" novalidate v-on:submit.prevent>

--- a/src/mixins/baseComponent.js
+++ b/src/mixins/baseComponent.js
@@ -50,6 +50,13 @@ var baseComponent = {
     },
     editing: {
       type: Boolean
+    },
+    isExternalMessage: {
+      type: Boolean,
+      default: false
+    },
+    externalMessageText: {
+      type: String
     }
   },
   watch: {

--- a/src/utils/externalMessages.js
+++ b/src/utils/externalMessages.js
@@ -1,5 +1,11 @@
 function checkIsExternalMessage(document) {
-  return document && document.metadata && document.metadata['#messageEmitter'] === 'externalMessages'
+  const isExternalMessage = Boolean(
+    document &&
+    document.metadata &&
+    document.metadata['#messageEmitter'] &&
+    document.metadata['#messageEmitter'] === 'externalMessages'
+  )
+  return isExternalMessage
 }
 
 export {

--- a/src/utils/externalMessages.js
+++ b/src/utils/externalMessages.js
@@ -1,0 +1,7 @@
+function checkIsExternalMessage(document) {
+  return document && document.metadata && document.metadata['#messageEmitter'] === 'externalMessages'
+}
+
+export {
+  checkIsExternalMessage
+}


### PR DESCRIPTION
There is a new scenario where, besides the bot/desk and the user, a third party could join the conversation.

To differentiate if the message came from the bot/desk or the other user we created a new flag to be shown together with the send date.

We had to also change the card grouping rule, to not group cards sent from different senders.

And we refactored some card types to use the same date/external message component.