### PR TITLE
fix(ExternalMessage): Fixing metadata validation when document or message

### DIFF
--- a/src/components/BlipGroupCard.vue
+++ b/src/components/BlipGroupCard.vue
@@ -38,7 +38,7 @@
           :position="group.position"
           :date="group.date"
           :failed-to-send-msg="failedMessageNotification(group.msgs[0].type)"
-          :is-external-message="checkIsExternalMessage(group.msgs[0].document)"
+          :is-external-message="checkIsExternalMessage(group.msgs[0])"
           :external-message-text="externalMessageText"
           :is-group="true"
           :show-alert-icon="Boolean(onFailedClickIcon)"

--- a/src/components/CopyAndPaste.vue
+++ b/src/components/CopyAndPaste.vue
@@ -25,7 +25,7 @@
             <bds-typo class="typo copy-and-paste-info-text" v-show="this.document.footer" italic="true" variant="fs-10">{{ this.document.footer }}</bds-typo>
           </bds-grid>
           <hr class="copy-and-paste-horizontal-divider">
-          <bds-grid direction="row" align-items="center" justify-content="center" class="button-container" padding="y-1" margin="x-2" gap="1" @click="writeToClipboard">
+          <bds-grid direction="row" align-items="center" justify-content="center" class="button-container" gap="1" @click="writeToClipboard">
             <bds-icon name="copy" :class="'button-container-text-' + (position == 'right' ? 'white' : 'primary')"></bds-icon>
             <bds-typo :class="'button-container-text-' + (position == 'right' ? 'white' : 'primary')">{{ this.document.button.text }}</bds-typo>
           </bds-grid>
@@ -266,13 +266,13 @@
         if (this.errors.any() || ($event && $event.shiftKey)) {
           return
         }
-  
+
         if ($event) {
           $event.stopPropagation()
           $event.preventDefault()
           $event.returnValue = false
         }
-  
+
         this.$validator.validateAll().then((result) => {
           if (!result) {
             return
@@ -305,7 +305,8 @@
 }
 
 .button-container {
-  width: -webkit-fill-available;
+  width: 100%;
+  padding: 8px 16px;
   cursor: pointer;
 }
 

--- a/src/utils/externalMessages.js
+++ b/src/utils/externalMessages.js
@@ -1,10 +1,19 @@
-function checkIsExternalMessage(document) {
+function checkIsExternalMessage(msg) {
+  let innerDocument
+
+  if (msg && msg.document) {
+    innerDocument = msg.document
+  } else {
+    innerDocument = msg
+  }
+
   const isExternalMessage = Boolean(
-    document &&
-    document.metadata &&
-    document.metadata['messageEmitter'] &&
-    document.metadata['messageEmitter'] === 'externalMessages'
+    innerDocument &&
+    innerDocument.metadata &&
+    innerDocument.metadata['messageEmitter'] &&
+    innerDocument.metadata['messageEmitter'] === 'externalMessages'
   )
+
   return isExternalMessage
 }
 


### PR DESCRIPTION
fix(ExternalMessage): Fixing metadata validation when document or message

There are cases where it is necessary to check if a message has a document with a metadata for external messages and if you already have the document in hand