### PR TITLE
#697246 add call to action (CTA) support

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -146,6 +146,9 @@
         <button class="button" @click="sendContact">
           ENVIAR Contato
         </button>
+        <button class="button" @click="sendCallToAction">
+          ENVIAR Conteúdo dinâmico (CTA)
+        </button>
         <button class="button" @click="sendMenuList">
           ENVIAR Menu List
         </button>
@@ -810,6 +813,37 @@ export default {
           },
           firstName: 'Contact',
           lastName: 'Last Name'
+        }
+      })
+      this.send()
+    },
+    sendCallToAction: function() {
+      this.json = JSON.stringify({
+        id: '1',
+        to: '128271320123982@wa.gw.msging.net',
+        type: 'application/json',
+        content: {
+          recipient_type: 'individual',
+          type: 'interactive',
+          interactive: {
+            type: 'cta_url',
+            header: {
+              text: 'Available Dates'
+            },
+            body: {
+              text: 'Tap the button below to see available dates.'
+            },
+            footer: {
+              text: 'Dates subject to change.'
+            },
+            action: {
+              name: 'cta_url',
+              parameters: {
+                display_text: 'See Dates',
+                url: 'https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-cta-url-messages'
+              }
+            }
+          }
         }
       })
       this.send()

--- a/src/components/ApplicationJSon.vue
+++ b/src/components/ApplicationJSon.vue
@@ -1,5 +1,20 @@
 <template>
   <div class="blip-container">
+
+    <call-to-action
+      v-if="document.type === 'interactive' && document.interactive.type === 'cta_url'"
+      class="blip-card"
+      :postback-value-msg="translations.postbackValue"
+      :status="status"
+      :position="position"
+      :document="fullDocument.content"
+      :editable="editable"
+      :on-deleted="onDeleted"
+      :deletable="deletable"
+      :readonly="readonly"
+      @updated="emitUpdate"
+    />
+
     <menu-list-prompt
       v-if="document.type === 'interactive' && document.interactive.type === 'list'"
       class="blip-card"
@@ -87,6 +102,7 @@ import MenuList from './ApplicationJSon/MenuList'
 import { default as base } from '../mixins/baseComponent.js'
 import { isFailedMessage } from '../utils/misc'
 import MenuListPrompt from './ApplicationJSon/MenuListPrompt.vue'
+import CallToAction from './ApplicationJSon/CallToAction.vue'
 
 export default {
   name: 'application-json',
@@ -123,7 +139,8 @@ export default {
   mixins: [base],
   components: {
     MenuList,
-    MenuListPrompt
+    MenuListPrompt,
+    CallToAction
   },
   methods: {
     emitUpdate() {

--- a/src/components/ApplicationJSon.vue
+++ b/src/components/ApplicationJSon.vue
@@ -80,11 +80,8 @@
       :unsupported-content-msg="translations.unsupportedContent"
       :position="position"
       :document="document"
-      :on-save="saveCard"
       :editable="editable"
-      :on-deleted="deleteCard"
       :deletable="deletable"
-      :editing="isCardEditing"
       :on-cancel="cancel"
     />
 

--- a/src/components/ApplicationJSon/CallToAction.vue
+++ b/src/components/ApplicationJSon/CallToAction.vue
@@ -111,6 +111,52 @@
             >{{ errors.first('footerText') }}</bds-typo
           >         
         </div>
+        <div>
+          <textarea
+            @keydown.enter="callToActionSave($event)"
+            type="text"
+            name="headerText"
+            :class="{ 'input-error': errors.has('headerText') }"
+            v-validate="'required'"
+            class="form-control"
+            v-auto-expand
+            v-model="headerText"
+          />
+          <bds-typo
+            variant="fs-12"
+            v-show="errors.has('headerText')"
+            class="help input-error"
+            >{{ errors.first('headerText') }}</bds-typo
+          >         
+        </div>
+        <div>
+          <textarea
+            @keydown.enter="callToActionSave($event)"
+            type="text"
+            name="url"
+            :class="{ 'input-error': errors.has('url') }"
+            v-validate="'required'"
+            class="form-control"
+            v-auto-expand
+            v-model="url"
+          />
+          <bds-typo
+            variant="fs-12"
+            v-show="errors.has('url')"
+            class="help input-error"
+            >{{ errors.first('url') }}</bds-typo
+          >
+        </div>
+        <div class="form-group">
+          <select class="form-control">
+            <option disabled value>Target</option>
+            <option value="blank">Blank</option>
+            <option value="self">Self</option>
+            <option value="selfCompact">SelfCompact</option>
+            <option value="selfTall">SelfTall</option>
+          </select>
+        </div>
+      
       </div>
     </form>
   </div>
@@ -119,7 +165,6 @@
 <script>
 import { default as base } from '../../mixins/baseComponent.js'
 import { isFailedMessage } from '../../utils/misc'
-import Editable from '../Editable'
 
 export default {
   name: 'menu-list-prompt',
@@ -144,35 +189,29 @@ export default {
       buttonText: undefined,
       bodyText: undefined,
       footerText: undefined,
+      selectedOption: undefined,
+      url: undefined,
       isFailedMessage
     }
   },
   updated: function() {
     this.$emit('updated')
   },
-  mounted: function() {
-    this.updateImageMarginTop()
-  },
+
   methods: {
     init: function() {
       this.headerText = this.document.interactive.header.text
       this.bodyText = this.document.interactive.body.text
       this.footerText = this.document.interactive.footer.text
-      this.buttonText = this.document.interactive.action.button
+      this.url = this.document.interactive.action.parameters.url
+      this.selectedOption = { label: {}, value: {} }
     },
-    updateImageMarginTop: function() {
-      this.$emit('updated')
 
-      if (!Editable) return
-
-      setTimeout(() => {
-        this.updateImageMarginTop()
-      }, 100)
-    },
     callToActionSave: function($event) {
       if (this.errors.any() || ($event && $event.shiftKey)) {
         return
       }
+      this.selectedOption = { label: {}, value: {} }
 
       this.$validator.validateAll().then((result) => {
         if (!result) return

--- a/src/components/ApplicationJSon/CallToAction.vue
+++ b/src/components/ApplicationJSon/CallToAction.vue
@@ -2,12 +2,20 @@
   <div v-if="!isEditing" class="blip-container menu-list-prompt">
     <div :class="isFailedMessage(status, position)">
       <div :class="'bubble ' + position">
-        <div v-if="deletable" class="editIco trashIco" @click="trash(document)">
-          <img :src="trashSvg" />
-        </div>
-        <div v-if="editable && !isEditing" class="editIco" @click="toggleEdit">
-          <img :src="editSvg" />
-        </div>
+        <bds-button-icon v-if="deletable && !isEditing"
+        class="editIco trashIco icon-margin"
+        icon="trash"
+        variant="delete"
+        size="short"
+        v-on:click="trash(document)"
+      ></bds-button-icon>
+      <bds-button-icon v-if="editable && !isEditing"
+        class="editIco icon-margin"
+        icon="edit"
+        variant="primary"
+        size="short"
+        v-on:click="toggleEdit"
+      ></bds-button-icon>         
         <div class="disable-selection">
           <div class="header-text">
             <bds-typo
@@ -30,6 +38,20 @@
             >
           </div>
 
+          <div class="fixed-options">
+            <ul>
+              <li
+                @click="(editable ? null :select(item))"
+                :class="editable ? '' : ' pointer'"
+              >
+                <div class="align-center">
+                  <bds-icon class="typo" name="link" size="medium"  ></bds-icon>
+                  <bds-typo variant="fs-16">{{headerText}}</bds-typo>
+                </div>
+              </li>
+            </ul>
+          </div> 
+
         </div>
       </div>
     </div>
@@ -37,20 +59,25 @@
 
   <div class="blip-container menu-list-prompt" v-else>
     <form :class="'bubble ' + position" novalidate v-on:submit.prevent>
-      <button class="btn saveIco closeIco" @click="menuListEditCancel()">
-        <img :src="closeSvg" />
-      </button>
-      <button
-        class="btn saveIco"
-        :class="{ 'is-disabled': errors.any() }"
-        @click="menuListSave(bodyText)"
-      >
-        <img :src="approveSvg" />
-      </button>
+      <bds-button-icon 
+      class="btn saveIco closeIco"
+      icon="close"
+      variant="ghost"
+      size="short"
+      v-on:click="callToActionEditCancel()"
+    ></bds-button-icon>
+    <bds-button-icon 
+      class="btn saveIco"
+      icon="check"
+      variant="primary"
+      size="short"
+      :disabled="errors.any()"
+      v-on:click="callToActionSave(bodyText)"
+    ></bds-button-icon>      
       <div class="form-group">
         <div>
           <textarea
-            @keydown.enter="menuListSave($event)"
+            @keydown.enter="callToActionSave($event)"
             type="text"
             name="bodyText"
             :class="{ 'input-error': errors.has('bodyText') }"
@@ -68,7 +95,7 @@
         </div>
         <div>
           <textarea
-            @keydown.enter="menuListSave($event)"
+            @keydown.enter="callToActionSave($event)"
             type="text"
             name="footerText"
             :class="{ 'input-error': errors.has('footerText') }"
@@ -82,7 +109,7 @@
             v-show="errors.has('footerText')"
             class="help input-error"
             >{{ errors.first('footerText') }}</bds-typo
-          >
+          >         
         </div>
       </div>
     </form>
@@ -142,7 +169,7 @@ export default {
         this.updateImageMarginTop()
       }, 100)
     },
-    menuListSave: function($event) {
+    callToActionSave: function($event) {
       if (this.errors.any() || ($event && $event.shiftKey)) {
         return
       }
@@ -171,7 +198,7 @@ export default {
         })
       })
     },
-    menuListEditCancel: function() {
+    callToActionEditCancel: function() {
       this.cancel()
     }
   }
@@ -244,4 +271,32 @@ export default {
 .blip-card .form-group .help {
   padding: 0px;
 }
+
+.fixed-options ul {
+    margin: 0px;
+}
+
+.editing .fixed-options ul {
+  margin: 0px -10px;
+}
+
+.fixed-options ul .align-center {
+  display: flex;
+  align-items: center;
+  margin: 0 auto;
+  > bds-icon {
+    margin-right: 10px;
+    color: var(--color-primary, #1E6BF1) !important;    
+  }
+  > bds-typo {
+    color: var(--color-primary, #1E6BF1);
+  }
+
+}
+
+.blip-card .fixed-options li div, .blip-card .fixed-options li span{
+  width: auto;
+}
+
+
 </style>

--- a/src/components/ApplicationJSon/CallToAction.vue
+++ b/src/components/ApplicationJSon/CallToAction.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="!isEditing" class="blip-container menu-list-prompt">
+  <div v-if="!isEditing" class="blip-container call-to-action">
     <div :class="isFailedMessage(status, position)">
       <div :class="'bubble ' + position">
         <bds-button-icon v-if="deletable && !isEditing"
@@ -70,7 +70,7 @@
     </div>
   </div>
 
-  <div class="blip-container menu-list-prompt" v-else>
+  <div class="blip-container call-to-action" v-else>
     <form :class="'bubble ' + position" novalidate v-on:submit.prevent>
       <bds-button-icon 
       class="btn saveIco closeIco"
@@ -180,7 +180,7 @@ import { default as base } from '../../mixins/baseComponent.js'
 import { isFailedMessage } from '../../utils/misc'
 
 export default {
-  name: 'menu-list-prompt',
+  name: 'call-to-action',
   mixins: [base],
   props: {
     status: {
@@ -262,7 +262,7 @@ export default {
 <style scoped lang="scss">
 @import '../../styles/variables.scss';
 
-.menu-list-prompt .bubble {
+.call-to-action .bubble {
   padding: $bubble-padding;
   padding-left: 0px;
   padding-right: 0px;
@@ -352,7 +352,7 @@ export default {
   width: auto;
 }
 
-.menu-list-prompt .bubble{
+.call-to-action .bubble{
   padding: 10px 0 0 0;
 }
 

--- a/src/components/ApplicationJSon/CallToAction.vue
+++ b/src/components/ApplicationJSon/CallToAction.vue
@@ -1,0 +1,247 @@
+<template>
+  <div v-if="!isEditing" class="blip-container menu-list-prompt">
+    <div :class="isFailedMessage(status, position)">
+      <div :class="'bubble ' + position">
+        <div v-if="deletable" class="editIco trashIco" @click="trash(document)">
+          <img :src="trashSvg" />
+        </div>
+        <div v-if="editable && !isEditing" class="editIco" @click="toggleEdit">
+          <img :src="editSvg" />
+        </div>
+        <div class="disable-selection">
+          <div class="header-text">
+            <bds-typo
+              variant="fs-16"
+              bold="bold"
+              line-height="plus"
+              class="disable-selection typo"
+              v-bind:class="{ readonly: readonly }"
+              >{{ bodyText }}</bds-typo
+            >
+          </div>
+          <div class="footer-text">
+            <bds-typo
+              variant="fs-16"
+              bold="regular"
+              line-height="plus"
+              class="disable-selection typo"
+              v-bind:class="{ readonly: readonly }"
+              >{{ footerText }}</bds-typo
+            >
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="blip-container menu-list-prompt" v-else>
+    <form :class="'bubble ' + position" novalidate v-on:submit.prevent>
+      <button class="btn saveIco closeIco" @click="menuListEditCancel()">
+        <img :src="closeSvg" />
+      </button>
+      <button
+        class="btn saveIco"
+        :class="{ 'is-disabled': errors.any() }"
+        @click="menuListSave(bodyText)"
+      >
+        <img :src="approveSvg" />
+      </button>
+      <div class="form-group">
+        <div>
+          <textarea
+            @keydown.enter="menuListSave($event)"
+            type="text"
+            name="bodyText"
+            :class="{ 'input-error': errors.has('bodyText') }"
+            v-validate="'required'"
+            class="form-control"
+            v-auto-expand
+            v-model="bodyText"
+          />
+          <bds-typo
+            variant="fs-12"
+            v-show="errors.has('bodyText')"
+            class="help input-error"
+            >{{ errors.first('bodyText') }}</bds-typo
+          >
+        </div>
+        <div>
+          <textarea
+            @keydown.enter="menuListSave($event)"
+            type="text"
+            name="footerText"
+            :class="{ 'input-error': errors.has('footerText') }"
+            v-validate="'required'"
+            class="form-control"
+            v-auto-expand
+            v-model="footerText"
+          />
+          <bds-typo
+            variant="fs-12"
+            v-show="errors.has('footerText')"
+            class="help input-error"
+            >{{ errors.first('footerText') }}</bds-typo
+          >
+        </div>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script>
+import { default as base } from '../../mixins/baseComponent.js'
+import { isFailedMessage } from '../../utils/misc'
+import Editable from '../Editable'
+
+export default {
+  name: 'menu-list-prompt',
+  mixins: [base],
+  props: {
+    status: {
+      type: String,
+      default: ''
+    },
+    readonly: {
+      type: Boolean,
+      default: false
+    },
+    position: {
+      type: String,
+      default: 'right'
+    }
+  },
+  data: function() {
+    return {
+      headerText: undefined,
+      buttonText: undefined,
+      bodyText: undefined,
+      footerText: undefined,
+      isFailedMessage
+    }
+  },
+  updated: function() {
+    this.$emit('updated')
+  },
+  mounted: function() {
+    this.updateImageMarginTop()
+  },
+  methods: {
+    init: function() {
+      this.headerText = this.document.interactive.header.text
+      this.bodyText = this.document.interactive.body.text
+      this.footerText = this.document.interactive.footer.text
+      this.buttonText = this.document.interactive.action.button
+    },
+    updateImageMarginTop: function() {
+      this.$emit('updated')
+
+      if (!Editable) return
+
+      setTimeout(() => {
+        this.updateImageMarginTop()
+      }, 100)
+    },
+    menuListSave: function($event) {
+      if (this.errors.any() || ($event && $event.shiftKey)) {
+        return
+      }
+
+      this.$validator.validateAll().then((result) => {
+        if (!result) return
+
+        this.save({
+          ...this.document.interactive.header,
+          text: this.headerText
+        })
+
+        this.save({
+          ...this.document.interactive.body,
+          text: this.bodyText
+        })
+
+        this.save({
+          ...this.document.interactive.footer,
+          text: this.footerText
+        })
+
+        this.save({
+          ...this.document.interactive.action,
+          button: this.buttonText
+        })
+      })
+    },
+    menuListEditCancel: function() {
+      this.cancel()
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+@import '../../styles/variables.scss';
+
+.menu-list-prompt .bubble {
+  padding: $bubble-padding;
+  padding-left: 0px;
+  padding-right: 0px;
+  min-width: 206px;
+  text-align: left;
+}
+
+.header-text {
+  padding-top: 0px !important;
+  padding-bottom: 0px !important;
+  padding: $bubble-padding;
+}
+
+.body-text, .footer-text {
+  padding-top: 0px !important;
+  padding-bottom: 10px !important;
+  padding: $bubble-padding;
+}
+
+.button-text {
+  padding-top: 0px !important;
+  padding-bottom: 0px !important;
+  padding: $bubble-padding;
+  border-top: 0.5px solid $color-content-ghost;
+
+  div:first-child {
+    text-align: center;
+    display: inline-flex;
+  }
+}
+
+.menu-list-options-button-icon .lmenu-list-options-button-text {
+  float: left;
+}
+
+.menu-list-options-button-icon {
+  margin-top: 12px;
+}
+.bubble {
+  &.right {
+    .disable-selection {
+      .button-text {
+        .menu-list-options-button-icon {
+          color: $color-surface-1;
+        }
+      }
+    }
+  }
+  
+  &.left {
+    .disable-selection {
+      .button-text {
+        .menu-list-options-button-icon {
+          color: $color-content-default;
+        }
+      }
+    }
+  }
+}
+.blip-card .form-group .help {
+  padding: 0px;
+}
+</style>

--- a/src/components/ApplicationJSon/CallToAction.vue
+++ b/src/components/ApplicationJSon/CallToAction.vue
@@ -30,6 +30,7 @@
             >
           </div>
           <div
+            v-if="bodyText"
             :class="headerText ? 'body-text' : 'header-text'"
           >
             <bds-typo
@@ -41,7 +42,9 @@
               >{{ bodyText }}</bds-typo
             >
           </div>
-          <div class="footer-text">
+          <div 
+            v-if="footerText"
+            class="footer-text">
             <bds-typo
               variant="fs-16"
               bold="regular"
@@ -52,7 +55,9 @@
             >
           </div>
           <div class="fixed-options">
-            <ul>
+            <ul
+              :class="headerText || bodyText || footer ? '' : 'border-top-none'"
+            >
               <li
                 v-on:click="callToActionSelectedOption()"
                 :class="editable ? '' : ' pointer'"
@@ -94,7 +99,6 @@
             type="text"
             name="headerText"
             :class="{ 'input-error': errors.has('headerText') }"
-            v-validate="'required'"
             class="form-control"
             v-auto-expand
             v-model="headerText"
@@ -104,7 +108,6 @@
             type="text"
             name="bodyText"
             :class="{ 'input-error': errors.has('bodyText') }"
-            v-validate="'required'"
             class="form-control"
             v-auto-expand
             v-model="bodyText"
@@ -122,7 +125,6 @@
             type="text"
             name="footerText"
             :class="{ 'input-error': errors.has('footerText') }"
-            v-validate="'required'"
             class="form-control"
             v-auto-expand
             v-model="footerText"
@@ -214,9 +216,9 @@ export default {
 
   methods: {
     init: function() {
-      this.headerText = this.document.interactive.header.text
-      this.bodyText = this.document.interactive.body.text
-      this.footerText = this.document.interactive.footer.text
+      this.headerText = this.document.interactive.header ? this.document.interactive.header.text : ''
+      this.bodyText = this.document.interactive.body ? this.document.interactive.body.text : ''
+      this.footerText = this.document.interactive.footer ? this.document.interactive.footer.text : ''
       this.url = this.document.interactive.action.parameters.url
       this.displayText = this.document.interactive.action.parameters.display_text
     },
@@ -354,6 +356,10 @@ export default {
 
 .call-to-action .bubble{
   padding: 10px 0 0 0;
+}
+
+.border-top-none li {
+  border-top: none !important;
 }
 
 

--- a/src/components/ApplicationJSon/CallToAction.vue
+++ b/src/components/ApplicationJSon/CallToAction.vue
@@ -363,6 +363,4 @@ export default {
 .border-top-none li {
   border-top: none !important;
 }
-
-
 </style>

--- a/src/components/ApplicationJSon/CallToAction.vue
+++ b/src/components/ApplicationJSon/CallToAction.vue
@@ -41,7 +41,7 @@
           <div class="fixed-options">
             <ul>
               <li
-                @click="(editable ? null :select(item))"
+                v-on:click="callToActionSelectedOption()"
                 :class="editable ? '' : ' pointer'"
               >
                 <div class="align-center">
@@ -146,17 +146,7 @@
             class="help input-error"
             >{{ errors.first('url') }}</bds-typo
           >
-        </div>
-        <div class="form-group">
-          <select class="form-control">
-            <option disabled value>Target</option>
-            <option value="blank">Blank</option>
-            <option value="self">Self</option>
-            <option value="selfCompact">SelfCompact</option>
-            <option value="selfTall">SelfTall</option>
-          </select>
-        </div>
-      
+        </div>      
       </div>
     </form>
   </div>
@@ -204,15 +194,15 @@ export default {
       this.bodyText = this.document.interactive.body.text
       this.footerText = this.document.interactive.footer.text
       this.url = this.document.interactive.action.parameters.url
-      this.selectedOption = { label: {}, value: {} }
     },
-
+    callToActionSelectedOption: function() {
+      let win = window.open(this.url, '_blank')
+      win.focus()
+    },
     callToActionSave: function($event) {
       if (this.errors.any() || ($event && $event.shiftKey)) {
         return
       }
-      this.selectedOption = { label: {}, value: {} }
-
       this.$validator.validateAll().then((result) => {
         if (!result) return
 

--- a/src/components/ApplicationJSon/CallToAction.vue
+++ b/src/components/ApplicationJSon/CallToAction.vue
@@ -17,10 +17,24 @@
         v-on:click="toggleEdit"
       ></bds-button-icon>         
         <div class="disable-selection">
-          <div class="header-text">
+          <div
+            v-if="headerText"
+            class="header-text">
             <bds-typo
               variant="fs-16"
               bold="bold"
+              line-height="plus"
+              class="disable-selection typo"
+              v-bind:class="{ readonly: readonly }"
+              >{{ headerText }}</bds-typo
+            >
+          </div>
+          <div
+            :class="headerText ? 'body-text' : 'header-text'"
+          >
+            <bds-typo
+              variant="fs-16"
+              :bold="headerText ? 'regular' : 'bold'"
               line-height="plus"
               class="disable-selection typo"
               v-bind:class="{ readonly: readonly }"
@@ -37,7 +51,6 @@
               >{{ footerText }}</bds-typo
             >
           </div>
-
           <div class="fixed-options">
             <ul>
               <li
@@ -79,6 +92,16 @@
           <textarea
             @keydown.enter="callToActionSave($event)"
             type="text"
+            name="headerText"
+            :class="{ 'input-error': errors.has('headerText') }"
+            v-validate="'required'"
+            class="form-control"
+            v-auto-expand
+            v-model="headerText"
+          />
+          <textarea
+            @keydown.enter="callToActionSave($event)"
+            type="text"
             name="bodyText"
             :class="{ 'input-error': errors.has('bodyText') }"
             v-validate="'required'"
@@ -115,8 +138,8 @@
           <textarea
             @keydown.enter="callToActionSave($event)"
             type="text"
-            name="headerText"
-            :class="{ 'input-error': errors.has('headerText') }"
+            name="displayText"
+            :class="{ 'input-error': errors.has('displayText') }"
             v-validate="'required'"
             class="form-control"
             v-auto-expand
@@ -124,9 +147,9 @@
           />
           <bds-typo
             variant="fs-12"
-            v-show="errors.has('headerText')"
+            v-show="errors.has('displayText')"
             class="help input-error"
-            >{{ errors.first('headerText') }}</bds-typo
+            >{{ errors.first('displayText') }}</bds-typo
           >         
         </div>
         <div>

--- a/src/components/ApplicationJSon/CallToAction.vue
+++ b/src/components/ApplicationJSon/CallToAction.vue
@@ -1,7 +1,9 @@
 <template>
   <div v-if="!isEditing" class="blip-container call-to-action">
     <div :class="isFailedMessage(status, position)">
-      <div :class="'bubble ' + position">
+      <div
+      :class="headerText || bodyText || footer ? 'bubble ' + position + ' bubble-padding-top-10': 'bubble ' + position"
+      >
         <bds-button-icon v-if="deletable && !isEditing"
         class="editIco trashIco icon-margin"
         icon="trash"
@@ -354,7 +356,7 @@ export default {
   width: auto;
 }
 
-.call-to-action .bubble{
+.call-to-action .bubble.bubble-padding-top-10 {
   padding: 10px 0 0 0;
 }
 

--- a/src/components/ApplicationJSon/CallToAction.vue
+++ b/src/components/ApplicationJSon/CallToAction.vue
@@ -344,10 +344,10 @@ export default {
   margin: 0 auto;
   > bds-icon {
     margin-right: 10px;
-    color: var(--color-primary, #1E6BF1) !important;    
+    color: $color-primary !important;    
   }
   > bds-typo {
-    color: var(--color-primary, #1E6BF1);
+    color: $color-primary;
   }
 
 }

--- a/src/components/ApplicationJSon/CallToAction.vue
+++ b/src/components/ApplicationJSon/CallToAction.vue
@@ -46,7 +46,7 @@
               >
                 <div class="align-center">
                   <bds-icon class="typo" name="link" size="medium"  ></bds-icon>
-                  <bds-typo variant="fs-16">{{headerText}}</bds-typo>
+                  <bds-typo variant="fs-16">{{displayText}}</bds-typo>
                 </div>
               </li>
             </ul>
@@ -120,7 +120,7 @@
             v-validate="'required'"
             class="form-control"
             v-auto-expand
-            v-model="headerText"
+            v-model="displayText"
           />
           <bds-typo
             variant="fs-12"
@@ -180,6 +180,7 @@ export default {
       bodyText: undefined,
       footerText: undefined,
       selectedOption: undefined,
+      displayText: undefined,
       url: undefined,
       isFailedMessage
     }
@@ -194,6 +195,7 @@ export default {
       this.bodyText = this.document.interactive.body.text
       this.footerText = this.document.interactive.footer.text
       this.url = this.document.interactive.action.parameters.url
+      this.displayText = this.document.interactive.action.parameters.display_text
     },
     callToActionSelectedOption: function() {
       let win = window.open(this.url, '_blank')
@@ -325,6 +327,10 @@ export default {
 
 .blip-card .fixed-options li div, .blip-card .fixed-options li span{
   width: auto;
+}
+
+.menu-list-prompt .bubble{
+  padding: 10px 0 0 0;
 }
 
 


### PR DESCRIPTION
**Motivation**
In order to support call-to-action (CTA) messages we created this component.

**Changes**
add CTA button
add call-to-action component
render call-to-action (CTA) message on cta_url type

**Reference**
https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-cta-url-messages