### PR TITLE
feat: create card componentorder AB#939927

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23525,11 +23525,6 @@
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div >
+  <div>
     <div class="float" style="width: 200px">
       <div>
         <h1>Width:</h1>
@@ -110,7 +110,9 @@
       <div v-if="isSample === 'true'">
         <h1>Examples:</h1>
         <button class="button" @click="sendReplyMessage1">Alfredo Teste</button>
-        <button class="button" @click="sendDeletedContent">Mensagem deletada</button>
+        <button class="button" @click="sendDeletedContent">
+          Mensagem deletada
+        </button>
         <button class="button" @click="sendText">ENVIAR Texto</button>
         <button class="button" @click="sendTextEmail">
           ENVIAR Texto contendo email
@@ -212,6 +214,9 @@
         <button class="button" @click="sendCopyAndPaste">
           ENVIAR copia e cola
         </button>
+        <button class="button" @click="sendOrderDetails">
+          ENVIAR componente order
+        </button>
         <button class="button" @click="sendThreadSummary">
           ENVIAR Resumo da conversa
         </button>
@@ -260,19 +265,22 @@
           <button class="button" @click="sendReplyTextMessageWithFailed">
             ENVIAR Reply Message de Falha
           </button>
-          
+
           <button class="button" @click="sendReplyImageMessageWithImage">
             ENVIAR Reply Message de Imagem com Imagem
           </button>
           <button class="button" @click="sendReplyLocationMessageWithText">
             ENVIAR Reply Message de Localização com Texto
           </button>
-          <button class="button" @click="sendReplyUnsuportedContentMessageWithText">
+          <button
+            class="button"
+            @click="sendReplyUnsuportedContentMessageWithText"
+          >
             ENVIAR Reply Message de 'Conteudo não suportado' com Texto
           </button>
           <button class="button" @click="sendReplyFailedMessageWithText">
             ENVIAR Reply Message de Falha com Texto
-          </button>          
+          </button>
           <button class="button" @click="sendReplyWebLinkMessageWithText">
             ENVIAR Reply Message de 'Web Link' com Texto
           </button>
@@ -294,13 +302,11 @@
           <button class="button" @click="sendReplyStickerWithSticker">
             ENVIAR Reply Sticker com Sticker
           </button>
-          
+
           <button class="button" @click="sendReplyStickerWithText">
             ENVIAR Reply texto com Sticker
           </button>
-          
-          
-        </div>  
+        </div>
       </div>
 
       <div v-else>
@@ -1168,7 +1174,8 @@ export default {
             type: 'application/vnd.lime.media-link+json',
             value: {
               type: 'sticker/webp',
-              uri: 'https://res.cloudinary.com/demo/image/upload/fl_awebp,q_40/bored_animation.webp'
+              uri:
+                'https://res.cloudinary.com/demo/image/upload/fl_awebp,q_40/bored_animation.webp'
             },
             direction: 'sent'
           }
@@ -1196,7 +1203,8 @@ export default {
             type: 'application/vnd.lime.media-link+json',
             value: {
               type: 'sticker/webp',
-              uri: 'https://blog.jiayu.co/2019/07/telegram-animated-stickers/sticker.webp'
+              uri:
+                'https://blog.jiayu.co/2019/07/telegram-animated-stickers/sticker.webp'
             },
             direction: 'sent'
           }
@@ -1282,6 +1290,171 @@ export default {
       })
       this.send()
     },
+
+    sendOrderDetails: function() {
+      this.json = JSON.stringify({
+        id: '16b0d902-7487-4c5c-b49c-8103558621e7',
+        direction: 'sent',
+        type: 'application/json',
+        content: {
+          type: 'interactive',
+          interactive: {
+            type: 'order_details',
+            header: {
+              type: 'document',
+              document: {
+                link: 'https://example.com/comprovante.pdf',
+                filename: 'Comprovante.pdf'
+              }
+            },
+            body: {
+              text:
+                'Finalize seu pedido!\nRealize o pagamento via Pix copia e cola usando o app do seu banco.'
+            },
+            footer: {
+              text: 'Blip Payments'
+            },
+            action: {
+              name: 'review_and_pay',
+              parameters: {
+                reference_id: '241942',
+                type: 'digital-goods',
+                payment_type: 'br',
+                currency: 'BRL',
+                total_amount: {
+                  value: '1500',
+                  offset: 100
+                },
+                order: {
+                  status: 'pending',
+                  items: [
+                    {
+                      retailer_id: '001',
+                      name: 'Product A',
+                      amount: {
+                        value: 500,
+                        offset: 100
+                      },
+                      quantity: 1
+                    },
+                    {
+                      retailer_id: '002',
+                      name: 'Product B',
+                      amount: {
+                        value: 750,
+                        offset: 150
+                      },
+                      quantity: 2
+                    },
+                    {
+                      retailer_id: '003',
+                      name: 'Product C',
+                      amount: {
+                        value: 1200,
+                        offset: 200
+                      },
+                      quantity: 1
+                    },
+                    {
+                      retailer_id: '004',
+                      name: 'Product D',
+                      amount: {
+                        value: 900,
+                        offset: 180
+                      },
+                      quantity: 3
+                    },
+                    {
+                      retailer_id: '005',
+                      name: 'Product E',
+                      amount: {
+                        value: 650,
+                        offset: 130
+                      },
+                      quantity: 1
+                    },
+                    {
+                      retailer_id: '006',
+                      name: 'Product F',
+                      amount: {
+                        value: 1100,
+                        offset: 220
+                      },
+                      quantity: 2
+                    },
+                    {
+                      retailer_id: '007',
+                      name: 'Product G',
+                      amount: {
+                        value: 300,
+                        offset: 60
+                      },
+                      quantity: 5
+                    },
+                    {
+                      retailer_id: '008',
+                      name: 'Product H',
+                      amount: {
+                        value: 2500,
+                        offset: 500
+                      },
+                      quantity: 1
+                    },
+                    {
+                      retailer_id: '009',
+                      name: 'Product I',
+                      amount: {
+                        value: 800,
+                        offset: 160
+                      },
+                      quantity: 2
+                    },
+                    {
+                      retailer_id: '010',
+                      name: 'Product J',
+                      amount: {
+                        value: 1500,
+                        offset: 300
+                      },
+                      quantity: 1
+                    }
+                  ],
+                  subtotal: {
+                    value: '1500',
+                    offset: 100
+                  }
+                },
+                payment_settings: [
+                  {
+                    type: 'pix_dynamic_code',
+                    pix_dynamic_code: {
+                      code:
+                        '00020126580014BR.GOV.BCB.PIX0136dda1eb4e-744f-4453-8074-a0ab5ffed3d85204000053039865802BR5921Gabriel Felix Petrone6009SAO PAULO62140510sF9EEKoAp56304AB67',
+                      merchant_name: 'Gabriel Petrone',
+                      key: '09351510603',
+                      key_type: 'CPF'
+                    }
+                  },
+                  {
+                    type: 'payment_link',
+                    payment_link: {
+                      url: 'https://pagamento.blip.ai/checkout/662311'
+                    }
+                  },
+                  {
+                    type: 'boleto',
+                    boleto: {
+                      digitable_line: '00190500954014481606906809350314337370000000100'
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      })
+      this.send()
+    },
     sendReplyDeletedMessage: function() {
       this.json = JSON.stringify({
         id: 'b1c3398f-ef63-426d-98b8-37ca84478f8f',
@@ -1296,7 +1469,7 @@ export default {
           inReplyTo: {
             id: 'b1c3398f-ef63-426d-98b8-37ca84478f8f',
             type: 'application/vnd.lime.deleted-content+json',
-            value: { }
+            value: {}
           }
         }
       })
@@ -1338,7 +1511,8 @@ export default {
             type: 'application/vnd.lime.media-link+json',
             value: {
               type: 'image/jpeg',
-              title: 'texto de exemplo texto de exemplo texto de exemplo texto de exemplo texto de exemplo texto de exemplo texto de exemplo texto de exemplo',
+              title:
+                'texto de exemplo texto de exemplo texto de exemplo texto de exemplo texto de exemplo texto de exemplo texto de exemplo texto de exemplo',
               uri:
                 'http://2.bp.blogspot.com/-pATX0YgNSFs/VP-82AQKcuI/AAAAAAAALSU/Vet9e7Qsjjw/s1600/Cat-hd-wallpapers.jpg'
             },
@@ -1609,7 +1783,8 @@ export default {
             type: 'application/vnd.lime.media-link+json',
             value: {
               type: 'audio/mp3',
-              uri: 'https://upload.wikimedia.org/wikipedia/commons/6/63/Sagetyrtle_-_citystreet3_%28cc0%29_%28freesound%29.mp3'
+              uri:
+                'https://upload.wikimedia.org/wikipedia/commons/6/63/Sagetyrtle_-_citystreet3_%28cc0%29_%28freesound%29.mp3'
             }
           },
           inReplyTo: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -217,6 +217,9 @@
         <button class="button" @click="sendOrderDetails">
           ENVIAR componente order
         </button>
+        <button class="button" @click="sendTemplateOrder">
+          ENVIAR Template order
+        </button>
         <button class="button" @click="sendThreadSummary">
           ENVIAR Resumo da conversa
         </button>
@@ -1450,6 +1453,145 @@ export default {
                 ]
               }
             }
+          }
+        }
+      })
+      this.send()
+    },
+    sendTemplateOrder: function() {
+      this.json = JSON.stringify({
+        id: '16b0d902-7487-4c5c-b49c-8103558621e7',
+        direction: 'sent',
+        type: 'template',
+        content: {
+          type: 'template',
+          template: {
+            language: {
+              policy: 'deterministic',
+              code: 'pt_BR'
+            },
+            name: 'solutions_template_order_pdf_conta',
+            components: [
+              {
+                type: 'header',
+                parameters: [
+                  {
+                    document: {
+                      filename: 'dummy',
+                      link: 'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf'
+                    },
+                    type: 'document'
+                  }
+                ]
+              },
+              {
+                type: 'body',
+                parameters: [
+                  {
+                    text: 'Wallace',
+                    type: 'text'
+                  },
+                  {
+                    text: '123456',
+                    type: 'text'
+                  },
+                  {
+                    text: '06/08',
+                    type: 'text'
+                  }
+                ]
+              },
+              {
+                sub_type: 'order_details',
+                index: '0',
+                type: 'button',
+                parameters: [
+                  {
+                    action: {
+                      order_details: {
+                        reference_id: '1234567',
+                        type: 'digital-goods',
+                        payment_type: 'br',
+                        payment_settings: [
+                          {
+                            type: 'pix_dynamic_code',
+                            pix_dynamic_code: {
+                              code: '00020126580014BR.GOV.BCB.PIX0136dda1eb4e-744f-4453-8074-a0ab5ffed3d85204000053039865802BR5921Gabriel Felix Petrone6009SAO PAULO62140510sF9EEKoAp56304AB67',
+                              merchant_name: 'Gabriel Petrone',
+                              key: 'gabriel.petrone@blip.ai',
+                              key_type: 'EMAIL'
+                            }
+                          }
+                        ],
+                        currency: 'BRL',
+                        total_amount: {
+                          value: 200,
+                          offset: 100
+                        },
+                        order: {
+                          status: 'pending',
+                          tax: {
+                            value: 0,
+                            offset: 100
+                          },
+                          items: [
+                            {
+                              retailer_id: '1234567',
+                              name: 'Presente Misterioso',
+                              amount: {
+                                value: 200,
+                                offset: 100
+                              },
+                              quantity: 1
+                            }
+                          ],
+                          subtotal: {
+                            value: 200,
+                            offset: 100
+                          }
+                        }
+                      }
+                    },
+                    type: 'action'
+                  }
+                ]
+              }
+            ]
+          },
+          templateContent: {
+            name: 'solutions_template_order_pdf_conta',
+            language: 'pt_BR',
+            components: [
+              {
+                type: 'HEADER',
+                format: 'DOCUMENT',
+                example: {
+                  headerHandle: [
+                    'https://scontent.whatsapp.net/v/t61.29466-34/513999863_1457412155675677_5375333688770231584_n.pdf?ccb=1-7&_nc_sid=8b1bef&_nc_ohc=L_To_BqM_bUQ7kNvwHNAGUW&_nc_oc=Adllcm8msngFAftelI04H-inksdIGLgnbCc9Ej9Y7vDqoEYgEHY6n6WiPQafk5cCmrM&_nc_zt=3&_nc_ht=scontent.whatsapp.net&edm=AH51TzQEAAAA&_nc_gid=AbvY-V1xSimoqKVypHJ1Zg&_nc_tpa=Q5bMBQEC7RM8QG4U8711alQFWxo-8ouDbUG99anRtn3GeaHyZryNcCmxitaXL9ai0LSFJz9VqOTQj8CY&oh=01_Q5Aa3AEhXBa8F14Jq5yB7Y6RXEV0BCxRU0629SmSaVRHXtZifQ&oe=693C2CAB'
+                  ]
+                }
+              },
+              {
+                type: 'BODY',
+                text: 'Olá {{1}},\nSua fatura {{2}} vence em {{3}}.\n\nPague agora mesmo e mantenha suas contas em dia.',
+                example: {
+                  bodyText: [['Gabriel', '1234', '01/08']]
+                }
+              },
+              {
+                type: 'FOOTER',
+                text: 'Pague somente se reconhecer a cobrança.'
+              },
+              {
+                type: 'BUTTONS',
+                buttons: [
+                  {
+                    type: 'ORDER_DETAILS',
+                    text: 'Copy Pix code'
+                  }
+                ]
+              }
+            ]
           }
         }
       })

--- a/src/App.vue
+++ b/src/App.vue
@@ -214,11 +214,23 @@
         <button class="button" @click="sendCopyAndPaste">
           ENVIAR copia e cola
         </button>
-        <button class="button" @click="sendOrderDetails">
-          ENVIAR componente order
+        <button class="button" @click="sendOrderDetailsText">
+          ENVIAR componente order TEXTO
         </button>
-        <button class="button" @click="sendTemplateOrder">
-          ENVIAR Template order
+        <button class="button" @click="sendOrderDetailsImage">
+          ENVIAR componente order IMAGEM
+        </button>
+        <button class="button" @click="sendOrderDetailsDocument">
+          ENVIAR componente order DOCUMENTO
+        </button>
+        <button class="button" @click="sendTemplateOrderText">
+          ENVIAR Template order Texto
+        </button>
+        <button class="button" @click="sendTemplateOrderDocument">
+          ENVIAR Template order Documento
+        </button>
+        <button class="button" @click="sendTemplateOrderImage">
+          ENVIAR Template order Imagem
         </button>
         <button class="button" @click="sendThreadSummary">
           ENVIAR Resumo da conversa
@@ -1294,7 +1306,7 @@ export default {
       this.send()
     },
 
-    sendOrderDetails: function() {
+    sendOrderDetailsDocument: function() {
       this.json = JSON.stringify({
         id: '16b0d902-7487-4c5c-b49c-8103558621e7',
         direction: 'sent',
@@ -1447,7 +1459,8 @@ export default {
                   {
                     type: 'boleto',
                     boleto: {
-                      digitable_line: '00190500954014481606906809350314337370000000100'
+                      digitable_line:
+                        '00190500954014481606906809350314337370000000100'
                     }
                   }
                 ]
@@ -1458,49 +1471,347 @@ export default {
       })
       this.send()
     },
-    sendTemplateOrder: function() {
+    sendOrderDetailsImage: function() {
+      this.json = JSON.stringify({
+        id: '16b0d902-7487-4c5c-b49c-8103558621e7',
+        direction: 'sent',
+        type: 'application/json',
+        content: {
+          type: 'interactive',
+          interactive: {
+            type: 'order_details',
+            header: {
+              type: 'image',
+              image: {
+                link:
+                  'https://hmgmediastore.blob.core.windows.net/permanent/Media_4_63bd457e-e09f-4b1f-a26d-e4e614edc5fd'
+              }
+            },
+            body: {
+              text:
+                'Finalize seu pedido!\nRealize o pagamento via Pix copia e cola usando o app do seu banco.'
+            },
+            footer: {
+              text: 'Blip Payments'
+            },
+            action: {
+              name: 'review_and_pay',
+              parameters: {
+                reference_id: '241942',
+                type: 'digital-goods',
+                payment_type: 'br',
+                currency: 'BRL',
+                total_amount: {
+                  value: '1500',
+                  offset: 100
+                },
+                order: {
+                  status: 'pending',
+                  items: [
+                    {
+                      retailer_id: '001',
+                      name: 'Product A',
+                      amount: {
+                        value: 500,
+                        offset: 100
+                      },
+                      quantity: 1
+                    },
+                    {
+                      retailer_id: '002',
+                      name: 'Product B',
+                      amount: {
+                        value: 750,
+                        offset: 150
+                      },
+                      quantity: 2
+                    },
+                    {
+                      retailer_id: '003',
+                      name: 'Product C',
+                      amount: {
+                        value: 1200,
+                        offset: 200
+                      },
+                      quantity: 1
+                    },
+                    {
+                      retailer_id: '004',
+                      name: 'Product D',
+                      amount: {
+                        value: 900,
+                        offset: 180
+                      },
+                      quantity: 3
+                    },
+                    {
+                      retailer_id: '005',
+                      name: 'Product E',
+                      amount: {
+                        value: 650,
+                        offset: 130
+                      },
+                      quantity: 1
+                    },
+                    {
+                      retailer_id: '006',
+                      name: 'Product F',
+                      amount: {
+                        value: 1100,
+                        offset: 220
+                      },
+                      quantity: 2
+                    },
+                    {
+                      retailer_id: '007',
+                      name: 'Product G',
+                      amount: {
+                        value: 300,
+                        offset: 60
+                      },
+                      quantity: 5
+                    },
+                    {
+                      retailer_id: '008',
+                      name: 'Product H',
+                      amount: {
+                        value: 2500,
+                        offset: 500
+                      },
+                      quantity: 1
+                    },
+                    {
+                      retailer_id: '009',
+                      name: 'Product I',
+                      amount: {
+                        value: 800,
+                        offset: 160
+                      },
+                      quantity: 2
+                    },
+                    {
+                      retailer_id: '010',
+                      name: 'Product J',
+                      amount: {
+                        value: 1500,
+                        offset: 300
+                      },
+                      quantity: 1
+                    }
+                  ],
+                  subtotal: {
+                    value: '1500',
+                    offset: 100
+                  }
+                },
+                payment_settings: [
+                  {
+                    type: 'pix_dynamic_code',
+                    pix_dynamic_code: {
+                      code:
+                        '00020126580014BR.GOV.BCB.PIX0136dda1eb4e-744f-4453-8074-a0ab5ffed3d85204000053039865802BR5921Gabriel Felix Petrone6009SAO PAULO62140510sF9EEKoAp56304AB67',
+                      merchant_name: 'Gabriel Petrone',
+                      key: '09351510603',
+                      key_type: 'CPF'
+                    }
+                  },
+                  {
+                    type: 'payment_link',
+                    payment_link: {
+                      url: 'https://pagamento.blip.ai/checkout/662311'
+                    }
+                  },
+                  {
+                    type: 'boleto',
+                    boleto: {
+                      digitable_line:
+                        '00190500954014481606906809350314337370000000100'
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      })
+      this.send()
+    },
+    sendOrderDetailsText: function() {
+      this.json = JSON.stringify({
+        id: '16b0d902-7487-4c5c-b49c-8103558621e7',
+        direction: 'sent',
+        type: 'application/json',
+        content: {
+          type: 'interactive',
+          interactive: {
+            type: 'order_details',
+            header: {
+              type: 'text',
+              text: 'Olá XXX'
+            },
+            body: {
+              text:
+                'Finalize seu pedido!\nRealize o pagamento via Pix copia e cola usando o app do seu banco.'
+            },
+            footer: {
+              text: 'Blip Payments'
+            },
+            action: {
+              name: 'review_and_pay',
+              parameters: {
+                reference_id: '241942',
+                type: 'digital-goods',
+                payment_type: 'br',
+                currency: 'BRL',
+                total_amount: {
+                  value: '1500',
+                  offset: 100
+                },
+                order: {
+                  status: 'pending',
+                  items: [
+                    {
+                      retailer_id: '001',
+                      name: 'Product A',
+                      amount: {
+                        value: 500,
+                        offset: 100
+                      },
+                      quantity: 1
+                    },
+                    {
+                      retailer_id: '002',
+                      name: 'Product B',
+                      amount: {
+                        value: 750,
+                        offset: 150
+                      },
+                      quantity: 2
+                    },
+                    {
+                      retailer_id: '003',
+                      name: 'Product C',
+                      amount: {
+                        value: 1200,
+                        offset: 200
+                      },
+                      quantity: 1
+                    },
+                    {
+                      retailer_id: '004',
+                      name: 'Product D',
+                      amount: {
+                        value: 900,
+                        offset: 180
+                      },
+                      quantity: 3
+                    },
+                    {
+                      retailer_id: '005',
+                      name: 'Product E',
+                      amount: {
+                        value: 650,
+                        offset: 130
+                      },
+                      quantity: 1
+                    },
+                    {
+                      retailer_id: '006',
+                      name: 'Product F',
+                      amount: {
+                        value: 1100,
+                        offset: 220
+                      },
+                      quantity: 2
+                    },
+                    {
+                      retailer_id: '007',
+                      name: 'Product G',
+                      amount: {
+                        value: 300,
+                        offset: 60
+                      },
+                      quantity: 5
+                    },
+                    {
+                      retailer_id: '008',
+                      name: 'Product H',
+                      amount: {
+                        value: 2500,
+                        offset: 500
+                      },
+                      quantity: 1
+                    },
+                    {
+                      retailer_id: '009',
+                      name: 'Product I',
+                      amount: {
+                        value: 800,
+                        offset: 160
+                      },
+                      quantity: 2
+                    },
+                    {
+                      retailer_id: '010',
+                      name: 'Product J',
+                      amount: {
+                        value: 1500,
+                        offset: 300
+                      },
+                      quantity: 1
+                    }
+                  ],
+                  subtotal: {
+                    value: '1500',
+                    offset: 100
+                  }
+                },
+                payment_settings: [
+                  {
+                    type: 'pix_dynamic_code',
+                    pix_dynamic_code: {
+                      code:
+                        '00020126580014BR.GOV.BCB.PIX0136dda1eb4e-744f-4453-8074-a0ab5ffed3d85204000053039865802BR5921Gabriel Felix Petrone6009SAO PAULO62140510sF9EEKoAp56304AB67',
+                      merchant_name: 'Gabriel Petrone',
+                      key: '09351510603',
+                      key_type: 'CPF'
+                    }
+                  },
+                  {
+                    type: 'payment_link',
+                    payment_link: {
+                      url: 'https://pagamento.blip.ai/checkout/662311'
+                    }
+                  },
+                  {
+                    type: 'boleto',
+                    boleto: {
+                      digitable_line:
+                        '00190500954014481606906809350314337370000000100'
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      })
+      this.send()
+    },
+    sendTemplateOrderText: function() {
       this.json = JSON.stringify({
         id: '16b0d902-7487-4c5c-b49c-8103558621e7',
         direction: 'sent',
         type: 'template',
         content: {
-          type: 'template',
+          type: 'template-content',
           template: {
             language: {
               policy: 'deterministic',
               code: 'pt_BR'
             },
-            name: 'solutions_template_order_pdf_conta',
+            name: 'teste_payments_1',
             components: [
-              {
-                type: 'header',
-                parameters: [
-                  {
-                    document: {
-                      filename: 'dummy',
-                      link: 'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf'
-                    },
-                    type: 'document'
-                  }
-                ]
-              },
-              {
-                type: 'body',
-                parameters: [
-                  {
-                    text: 'Wallace',
-                    type: 'text'
-                  },
-                  {
-                    text: '123456',
-                    type: 'text'
-                  },
-                  {
-                    text: '06/08',
-                    type: 'text'
-                  }
-                ]
-              },
               {
                 sub_type: 'order_details',
                 index: '0',
@@ -1516,7 +1827,8 @@ export default {
                           {
                             type: 'pix_dynamic_code',
                             pix_dynamic_code: {
-                              code: '00020126580014BR.GOV.BCB.PIX0136dda1eb4e-744f-4453-8074-a0ab5ffed3d85204000053039865802BR5921Gabriel Felix Petrone6009SAO PAULO62140510sF9EEKoAp56304AB67',
+                              code:
+                                '00020126580014BR.GOV.BCB.PIX0136dda1eb4e-744f-4453-8074-a0ab5ffed3d85204000053039865802BR5921Gabriel Felix Petrone6009SAO PAULO62140510sF9EEKoAp56304AB67',
                               merchant_name: 'Gabriel Petrone',
                               key: 'gabriel.petrone@blip.ai',
                               key_type: 'EMAIL'
@@ -1559,7 +1871,115 @@ export default {
             ]
           },
           templateContent: {
-            name: 'solutions_template_order_pdf_conta',
+            name: 'teste_payments_1',
+            language: 'pt_BR',
+            components: [
+              {
+                type: 'BODY',
+                text: 'Olá.\\nSegue para pagamento.'
+              },
+              {
+                type: 'BUTTONS',
+                buttons: [
+                  {
+                    type: 'ORDER_DETAILS',
+                    text: 'Copy Pix code'
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      })
+      this.send()
+    },
+    sendTemplateOrderDocument: function() {
+      this.json = JSON.stringify({
+        id: '16b0d902-7487-4c5c-b49c-8103558621e7',
+        direction: 'sent',
+        type: 'template',
+        content: {
+          type: 'template-content',
+          template: {
+            language: {
+              policy: 'deterministic',
+              code: 'pt_BR'
+            },
+            name: 'teste_payments_1',
+            components: [
+              {
+                type: 'header',
+                parameters: [
+                  {
+                    document: {
+                      filename: 'dummy',
+                      link:
+                        'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf'
+                    },
+                    type: 'document'
+                  }
+                ]
+              },
+              {
+                sub_type: 'order_details',
+                index: '0',
+                type: 'button',
+                parameters: [
+                  {
+                    action: {
+                      order_details: {
+                        reference_id: '1234567',
+                        type: 'digital-goods',
+                        payment_type: 'br',
+                        payment_settings: [
+                          {
+                            type: 'pix_dynamic_code',
+                            pix_dynamic_code: {
+                              code:
+                                '00020126580014BR.GOV.BCB.PIX0136dda1eb4e-744f-4453-8074-a0ab5ffed3d85204000053039865802BR5921Gabriel Felix Petrone6009SAO PAULO62140510sF9EEKoAp56304AB67',
+                              merchant_name: 'Gabriel Petrone',
+                              key: 'gabriel.petrone@blip.ai',
+                              key_type: 'EMAIL'
+                            }
+                          }
+                        ],
+                        currency: 'BRL',
+                        total_amount: {
+                          value: 200,
+                          offset: 100
+                        },
+                        order: {
+                          status: 'pending',
+                          tax: {
+                            value: 0,
+                            offset: 100
+                          },
+                          items: [
+                            {
+                              retailer_id: '1234567',
+                              name: 'Presente Misterioso',
+                              amount: {
+                                value: 200,
+                                offset: 100
+                              },
+                              quantity: 1
+                            }
+                          ],
+                          subtotal: {
+                            value: 200,
+                            offset: 100
+                          }
+                        }
+                      }
+                    },
+                    type: 'action'
+                  }
+                ]
+              }
+            ]
+          },
+          templateContent: {
+            name: 'teste_payments_1',
             language: 'pt_BR',
             components: [
               {
@@ -1567,20 +1987,128 @@ export default {
                 format: 'DOCUMENT',
                 example: {
                   headerHandle: [
-                    'https://scontent.whatsapp.net/v/t61.29466-34/513999863_1457412155675677_5375333688770231584_n.pdf?ccb=1-7&_nc_sid=8b1bef&_nc_ohc=L_To_BqM_bUQ7kNvwHNAGUW&_nc_oc=Adllcm8msngFAftelI04H-inksdIGLgnbCc9Ej9Y7vDqoEYgEHY6n6WiPQafk5cCmrM&_nc_zt=3&_nc_ht=scontent.whatsapp.net&edm=AH51TzQEAAAA&_nc_gid=AbvY-V1xSimoqKVypHJ1Zg&_nc_tpa=Q5bMBQEC7RM8QG4U8711alQFWxo-8ouDbUG99anRtn3GeaHyZryNcCmxitaXL9ai0LSFJz9VqOTQj8CY&oh=01_Q5Aa3AEhXBa8F14Jq5yB7Y6RXEV0BCxRU0629SmSaVRHXtZifQ&oe=693C2CAB'
+                    'https://scontent.whatsapp.net/v/t61.29466-34/521274600_1869416363990860_4813441808641739597_n.pdf?ccb=1-7&_nc_sid=8b1bef&_nc_ohc=kaksJtUbzi4Q7kNvwFw_zUr&_nc_oc=Adn2h-Jk3rnqcup4orFp2edi06A0NqP9uAAtbs0d4Z_kQCizPy5p-2ewNG6m9l6gMHk&_nc_zt=3&_nc_ht=scontent.whatsapp.net&edm=AH51TzQEAAAA&_nc_gid=wqTRTF902E_ymJUSdLV9SA&oh=01_Q5Aa2QGc3jvj7DYE-q1HumUpl1rl2vY0g-yGhZ02Fu_yO02ksQ&oe=68DFDDE9'
                   ]
                 }
               },
               {
                 type: 'BODY',
-                text: 'Olá {{1}},\nSua fatura {{2}} vence em {{3}}.\n\nPague agora mesmo e mantenha suas contas em dia.',
+                text: 'Olá.\\nSegue para pagamento.'
+              },
+              {
+                type: 'BUTTONS',
+                buttons: [
+                  {
+                    type: 'ORDER_DETAILS',
+                    text: 'Copy Pix code'
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      })
+      this.send()
+    },
+    sendTemplateOrderImage: function() {
+      this.json = JSON.stringify({
+        id: '16b0d902-7487-4c5c-b49c-8103558621e7',
+        direction: 'sent',
+        type: 'template',
+        content: {
+          type: 'template-content',
+          template: {
+            name: 'teste_payments_1',
+            language: {
+              policy: 'deterministic',
+              code: 'pt_BR'
+            },
+            components: [
+              {
+                type: 'header',
+                parameters: [
+                  {
+                    type: 'image',
+                    image: {
+                      link: 'https://s3-sa-east-1.amazonaws.com/msging.net/iris/Media_ee3797dd-c943-4fd8-bddb-c3cf89d5fbfd'
+                    }
+                  }
+                ]
+              },
+              {
+                type: 'button',
+                sub_type: 'order_details',
+                index: '0',
+                parameters: [
+                  {
+                    type: 'action',
+                    action: {
+                      order_details: {
+                        reference_id: '1234567',
+                        type: 'digital-goods',
+                        payment_type: 'br',
+                        payment_settings: [
+                          {
+                            type: 'pix_dynamic_code',
+                            pix_dynamic_code: {
+                              code:
+                                '00020126580014BR.GOV.BCB.PIX0136dda1eb4e-744f-4453-8074-a0ab5ffed3d85204000053039865802BR5921Gabriel Felix Petrone6009SAO PAULO62140510sF9EEKoAp56304AB67',
+                              merchant_name: 'Gabriel Petrone',
+                              key: 'gabriel.petrone@blip.ai',
+                              key_type: 'EMAIL'
+                            }
+                          }
+                        ],
+                        currency: 'BRL',
+                        total_amount: {
+                          value: 200,
+                          offset: 100
+                        },
+                        order: {
+                          status: 'pending',
+                          tax: {
+                            value: 0,
+                            offset: 100
+                          },
+                          items: [
+                            {
+                              retailer_id: '1234567',
+                              name: 'Presente Misterioso',
+                              amount: {
+                                value: 200,
+                                offset: 100
+                              },
+                              quantity: 1
+                            }
+                          ],
+                          subtotal: {
+                            value: 200,
+                            offset: 100
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          templateContent: {
+            name: 'teste_payments_1',
+            language: 'pt_BR',
+            components: [
+              {
+                type: 'HEADER',
+                format: 'IMAGE',
                 example: {
-                  bodyText: [['Gabriel', '1234', '01/08']]
+                  headerHandle: [
+                    'https://s3-sa-east-1.amazonaws.com/msging.net/iris/Media_ee3797dd-c943-4fd8-bddb-c3cf89d5fbfd'
+                  ]
                 }
               },
               {
-                type: 'FOOTER',
-                text: 'Pague somente se reconhecer a cobrança.'
+                type: 'BODY',
+                text: 'Olá.\\nSegue para pagamento.'
               },
               {
                 type: 'BUTTONS',

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div >
     <div class="float" style="width: 200px">
       <div>
         <h1>Width:</h1>
@@ -110,9 +110,7 @@
       <div v-if="isSample === 'true'">
         <h1>Examples:</h1>
         <button class="button" @click="sendReplyMessage1">Alfredo Teste</button>
-        <button class="button" @click="sendDeletedContent">
-          Mensagem deletada
-        </button>
+        <button class="button" @click="sendDeletedContent">Mensagem deletada</button>
         <button class="button" @click="sendText">ENVIAR Texto</button>
         <button class="button" @click="sendTextEmail">
           ENVIAR Texto contendo email
@@ -214,24 +212,6 @@
         <button class="button" @click="sendCopyAndPaste">
           ENVIAR copia e cola
         </button>
-        <button class="button" @click="sendOrderDetailsText">
-          ENVIAR componente order TEXTO
-        </button>
-        <button class="button" @click="sendOrderDetailsImage">
-          ENVIAR componente order IMAGEM
-        </button>
-        <button class="button" @click="sendOrderDetailsDocument">
-          ENVIAR componente order DOCUMENTO
-        </button>
-        <button class="button" @click="sendTemplateOrderText">
-          ENVIAR Template order Texto
-        </button>
-        <button class="button" @click="sendTemplateOrderDocument">
-          ENVIAR Template order Documento
-        </button>
-        <button class="button" @click="sendTemplateOrderImage">
-          ENVIAR Template order Imagem
-        </button>
         <button class="button" @click="sendThreadSummary">
           ENVIAR Resumo da conversa
         </button>
@@ -280,22 +260,19 @@
           <button class="button" @click="sendReplyTextMessageWithFailed">
             ENVIAR Reply Message de Falha
           </button>
-
+          
           <button class="button" @click="sendReplyImageMessageWithImage">
             ENVIAR Reply Message de Imagem com Imagem
           </button>
           <button class="button" @click="sendReplyLocationMessageWithText">
             ENVIAR Reply Message de Localização com Texto
           </button>
-          <button
-            class="button"
-            @click="sendReplyUnsuportedContentMessageWithText"
-          >
+          <button class="button" @click="sendReplyUnsuportedContentMessageWithText">
             ENVIAR Reply Message de 'Conteudo não suportado' com Texto
           </button>
           <button class="button" @click="sendReplyFailedMessageWithText">
             ENVIAR Reply Message de Falha com Texto
-          </button>
+          </button>          
           <button class="button" @click="sendReplyWebLinkMessageWithText">
             ENVIAR Reply Message de 'Web Link' com Texto
           </button>
@@ -317,11 +294,13 @@
           <button class="button" @click="sendReplyStickerWithSticker">
             ENVIAR Reply Sticker com Sticker
           </button>
-
+          
           <button class="button" @click="sendReplyStickerWithText">
             ENVIAR Reply texto com Sticker
           </button>
-        </div>
+          
+          
+        </div>  
       </div>
 
       <div v-else>
@@ -1189,8 +1168,7 @@ export default {
             type: 'application/vnd.lime.media-link+json',
             value: {
               type: 'sticker/webp',
-              uri:
-                'https://res.cloudinary.com/demo/image/upload/fl_awebp,q_40/bored_animation.webp'
+              uri: 'https://res.cloudinary.com/demo/image/upload/fl_awebp,q_40/bored_animation.webp'
             },
             direction: 'sent'
           }
@@ -1218,8 +1196,7 @@ export default {
             type: 'application/vnd.lime.media-link+json',
             value: {
               type: 'sticker/webp',
-              uri:
-                'https://blog.jiayu.co/2019/07/telegram-animated-stickers/sticker.webp'
+              uri: 'https://blog.jiayu.co/2019/07/telegram-animated-stickers/sticker.webp'
             },
             direction: 'sent'
           }
@@ -1305,826 +1282,6 @@ export default {
       })
       this.send()
     },
-
-    sendOrderDetailsDocument: function() {
-      this.json = JSON.stringify({
-        id: '16b0d902-7487-4c5c-b49c-8103558621e7',
-        direction: 'sent',
-        type: 'application/json',
-        content: {
-          type: 'interactive',
-          interactive: {
-            type: 'order_details',
-            header: {
-              type: 'document',
-              document: {
-                link: 'https://example.com/comprovante.pdf',
-                filename: 'Comprovante.pdf'
-              }
-            },
-            body: {
-              text:
-                'Finalize seu pedido!\nRealize o pagamento via Pix copia e cola usando o app do seu banco.'
-            },
-            footer: {
-              text: 'Blip Payments'
-            },
-            action: {
-              name: 'review_and_pay',
-              parameters: {
-                reference_id: '241942',
-                type: 'digital-goods',
-                payment_type: 'br',
-                currency: 'BRL',
-                total_amount: {
-                  value: '1500',
-                  offset: 100
-                },
-                order: {
-                  status: 'pending',
-                  items: [
-                    {
-                      retailer_id: '001',
-                      name: 'Product A',
-                      amount: {
-                        value: 500,
-                        offset: 100
-                      },
-                      quantity: 1
-                    },
-                    {
-                      retailer_id: '002',
-                      name: 'Product B',
-                      amount: {
-                        value: 750,
-                        offset: 150
-                      },
-                      quantity: 2
-                    },
-                    {
-                      retailer_id: '003',
-                      name: 'Product C',
-                      amount: {
-                        value: 1200,
-                        offset: 200
-                      },
-                      quantity: 1
-                    },
-                    {
-                      retailer_id: '004',
-                      name: 'Product D',
-                      amount: {
-                        value: 900,
-                        offset: 180
-                      },
-                      quantity: 3
-                    },
-                    {
-                      retailer_id: '005',
-                      name: 'Product E',
-                      amount: {
-                        value: 650,
-                        offset: 130
-                      },
-                      quantity: 1
-                    },
-                    {
-                      retailer_id: '006',
-                      name: 'Product F',
-                      amount: {
-                        value: 1100,
-                        offset: 220
-                      },
-                      quantity: 2
-                    },
-                    {
-                      retailer_id: '007',
-                      name: 'Product G',
-                      amount: {
-                        value: 300,
-                        offset: 60
-                      },
-                      quantity: 5
-                    },
-                    {
-                      retailer_id: '008',
-                      name: 'Product H',
-                      amount: {
-                        value: 2500,
-                        offset: 500
-                      },
-                      quantity: 1
-                    },
-                    {
-                      retailer_id: '009',
-                      name: 'Product I',
-                      amount: {
-                        value: 800,
-                        offset: 160
-                      },
-                      quantity: 2
-                    },
-                    {
-                      retailer_id: '010',
-                      name: 'Product J',
-                      amount: {
-                        value: 1500,
-                        offset: 300
-                      },
-                      quantity: 1
-                    }
-                  ],
-                  subtotal: {
-                    value: '1500',
-                    offset: 100
-                  }
-                },
-                payment_settings: [
-                  {
-                    type: 'pix_dynamic_code',
-                    pix_dynamic_code: {
-                      code:
-                        '00020126580014BR.GOV.BCB.PIX0136dda1eb4e-744f-4453-8074-a0ab5ffed3d85204000053039865802BR5921Gabriel Felix Petrone6009SAO PAULO62140510sF9EEKoAp56304AB67',
-                      merchant_name: 'Gabriel Petrone',
-                      key: '09351510603',
-                      key_type: 'CPF'
-                    }
-                  },
-                  {
-                    type: 'payment_link',
-                    payment_link: {
-                      url: 'https://pagamento.blip.ai/checkout/662311'
-                    }
-                  },
-                  {
-                    type: 'boleto',
-                    boleto: {
-                      digitable_line:
-                        '00190500954014481606906809350314337370000000100'
-                    }
-                  }
-                ]
-              }
-            }
-          }
-        }
-      })
-      this.send()
-    },
-    sendOrderDetailsImage: function() {
-      this.json = JSON.stringify({
-        id: '16b0d902-7487-4c5c-b49c-8103558621e7',
-        direction: 'sent',
-        type: 'application/json',
-        content: {
-          type: 'interactive',
-          interactive: {
-            type: 'order_details',
-            header: {
-              type: 'image',
-              image: {
-                link:
-                  'https://hmgmediastore.blob.core.windows.net/permanent/Media_4_63bd457e-e09f-4b1f-a26d-e4e614edc5fd'
-              }
-            },
-            body: {
-              text:
-                'Finalize seu pedido!\nRealize o pagamento via Pix copia e cola usando o app do seu banco.'
-            },
-            footer: {
-              text: 'Blip Payments'
-            },
-            action: {
-              name: 'review_and_pay',
-              parameters: {
-                reference_id: '241942',
-                type: 'digital-goods',
-                payment_type: 'br',
-                currency: 'BRL',
-                total_amount: {
-                  value: '1500',
-                  offset: 100
-                },
-                order: {
-                  status: 'pending',
-                  items: [
-                    {
-                      retailer_id: '001',
-                      name: 'Product A',
-                      amount: {
-                        value: 500,
-                        offset: 100
-                      },
-                      quantity: 1
-                    },
-                    {
-                      retailer_id: '002',
-                      name: 'Product B',
-                      amount: {
-                        value: 750,
-                        offset: 150
-                      },
-                      quantity: 2
-                    },
-                    {
-                      retailer_id: '003',
-                      name: 'Product C',
-                      amount: {
-                        value: 1200,
-                        offset: 200
-                      },
-                      quantity: 1
-                    },
-                    {
-                      retailer_id: '004',
-                      name: 'Product D',
-                      amount: {
-                        value: 900,
-                        offset: 180
-                      },
-                      quantity: 3
-                    },
-                    {
-                      retailer_id: '005',
-                      name: 'Product E',
-                      amount: {
-                        value: 650,
-                        offset: 130
-                      },
-                      quantity: 1
-                    },
-                    {
-                      retailer_id: '006',
-                      name: 'Product F',
-                      amount: {
-                        value: 1100,
-                        offset: 220
-                      },
-                      quantity: 2
-                    },
-                    {
-                      retailer_id: '007',
-                      name: 'Product G',
-                      amount: {
-                        value: 300,
-                        offset: 60
-                      },
-                      quantity: 5
-                    },
-                    {
-                      retailer_id: '008',
-                      name: 'Product H',
-                      amount: {
-                        value: 2500,
-                        offset: 500
-                      },
-                      quantity: 1
-                    },
-                    {
-                      retailer_id: '009',
-                      name: 'Product I',
-                      amount: {
-                        value: 800,
-                        offset: 160
-                      },
-                      quantity: 2
-                    },
-                    {
-                      retailer_id: '010',
-                      name: 'Product J',
-                      amount: {
-                        value: 1500,
-                        offset: 300
-                      },
-                      quantity: 1
-                    }
-                  ],
-                  subtotal: {
-                    value: '1500',
-                    offset: 100
-                  }
-                },
-                payment_settings: [
-                  {
-                    type: 'pix_dynamic_code',
-                    pix_dynamic_code: {
-                      code:
-                        '00020126580014BR.GOV.BCB.PIX0136dda1eb4e-744f-4453-8074-a0ab5ffed3d85204000053039865802BR5921Gabriel Felix Petrone6009SAO PAULO62140510sF9EEKoAp56304AB67',
-                      merchant_name: 'Gabriel Petrone',
-                      key: '09351510603',
-                      key_type: 'CPF'
-                    }
-                  },
-                  {
-                    type: 'payment_link',
-                    payment_link: {
-                      url: 'https://pagamento.blip.ai/checkout/662311'
-                    }
-                  },
-                  {
-                    type: 'boleto',
-                    boleto: {
-                      digitable_line:
-                        '00190500954014481606906809350314337370000000100'
-                    }
-                  }
-                ]
-              }
-            }
-          }
-        }
-      })
-      this.send()
-    },
-    sendOrderDetailsText: function() {
-      this.json = JSON.stringify({
-        id: '16b0d902-7487-4c5c-b49c-8103558621e7',
-        direction: 'sent',
-        type: 'application/json',
-        content: {
-          type: 'interactive',
-          interactive: {
-            type: 'order_details',
-            header: {
-              type: 'text',
-              text: 'Olá XXX'
-            },
-            body: {
-              text:
-                'Finalize seu pedido!\nRealize o pagamento via Pix copia e cola usando o app do seu banco.'
-            },
-            footer: {
-              text: 'Blip Payments'
-            },
-            action: {
-              name: 'review_and_pay',
-              parameters: {
-                reference_id: '241942',
-                type: 'digital-goods',
-                payment_type: 'br',
-                currency: 'BRL',
-                total_amount: {
-                  value: '1500',
-                  offset: 100
-                },
-                order: {
-                  status: 'pending',
-                  items: [
-                    {
-                      retailer_id: '001',
-                      name: 'Product A',
-                      amount: {
-                        value: 500,
-                        offset: 100
-                      },
-                      quantity: 1
-                    },
-                    {
-                      retailer_id: '002',
-                      name: 'Product B',
-                      amount: {
-                        value: 750,
-                        offset: 150
-                      },
-                      quantity: 2
-                    },
-                    {
-                      retailer_id: '003',
-                      name: 'Product C',
-                      amount: {
-                        value: 1200,
-                        offset: 200
-                      },
-                      quantity: 1
-                    },
-                    {
-                      retailer_id: '004',
-                      name: 'Product D',
-                      amount: {
-                        value: 900,
-                        offset: 180
-                      },
-                      quantity: 3
-                    },
-                    {
-                      retailer_id: '005',
-                      name: 'Product E',
-                      amount: {
-                        value: 650,
-                        offset: 130
-                      },
-                      quantity: 1
-                    },
-                    {
-                      retailer_id: '006',
-                      name: 'Product F',
-                      amount: {
-                        value: 1100,
-                        offset: 220
-                      },
-                      quantity: 2
-                    },
-                    {
-                      retailer_id: '007',
-                      name: 'Product G',
-                      amount: {
-                        value: 300,
-                        offset: 60
-                      },
-                      quantity: 5
-                    },
-                    {
-                      retailer_id: '008',
-                      name: 'Product H',
-                      amount: {
-                        value: 2500,
-                        offset: 500
-                      },
-                      quantity: 1
-                    },
-                    {
-                      retailer_id: '009',
-                      name: 'Product I',
-                      amount: {
-                        value: 800,
-                        offset: 160
-                      },
-                      quantity: 2
-                    },
-                    {
-                      retailer_id: '010',
-                      name: 'Product J',
-                      amount: {
-                        value: 1500,
-                        offset: 300
-                      },
-                      quantity: 1
-                    }
-                  ],
-                  subtotal: {
-                    value: '1500',
-                    offset: 100
-                  }
-                },
-                payment_settings: [
-                  {
-                    type: 'pix_dynamic_code',
-                    pix_dynamic_code: {
-                      code:
-                        '00020126580014BR.GOV.BCB.PIX0136dda1eb4e-744f-4453-8074-a0ab5ffed3d85204000053039865802BR5921Gabriel Felix Petrone6009SAO PAULO62140510sF9EEKoAp56304AB67',
-                      merchant_name: 'Gabriel Petrone',
-                      key: '09351510603',
-                      key_type: 'CPF'
-                    }
-                  },
-                  {
-                    type: 'payment_link',
-                    payment_link: {
-                      url: 'https://pagamento.blip.ai/checkout/662311'
-                    }
-                  },
-                  {
-                    type: 'boleto',
-                    boleto: {
-                      digitable_line:
-                        '00190500954014481606906809350314337370000000100'
-                    }
-                  }
-                ]
-              }
-            }
-          }
-        }
-      })
-      this.send()
-    },
-    sendTemplateOrderText: function() {
-      this.json = JSON.stringify({
-        id: '16b0d902-7487-4c5c-b49c-8103558621e7',
-        direction: 'sent',
-        type: 'template',
-        content: {
-          type: 'template-content',
-          template: {
-            language: {
-              policy: 'deterministic',
-              code: 'pt_BR'
-            },
-            name: 'teste_payments_1',
-            components: [
-              {
-                sub_type: 'order_details',
-                index: '0',
-                type: 'button',
-                parameters: [
-                  {
-                    action: {
-                      order_details: {
-                        reference_id: '1234567',
-                        type: 'digital-goods',
-                        payment_type: 'br',
-                        payment_settings: [
-                          {
-                            type: 'pix_dynamic_code',
-                            pix_dynamic_code: {
-                              code:
-                                '00020126580014BR.GOV.BCB.PIX0136dda1eb4e-744f-4453-8074-a0ab5ffed3d85204000053039865802BR5921Gabriel Felix Petrone6009SAO PAULO62140510sF9EEKoAp56304AB67',
-                              merchant_name: 'Gabriel Petrone',
-                              key: 'gabriel.petrone@blip.ai',
-                              key_type: 'EMAIL'
-                            }
-                          }
-                        ],
-                        currency: 'BRL',
-                        total_amount: {
-                          value: 200,
-                          offset: 100
-                        },
-                        order: {
-                          status: 'pending',
-                          tax: {
-                            value: 0,
-                            offset: 100
-                          },
-                          items: [
-                            {
-                              retailer_id: '1234567',
-                              name: 'Presente Misterioso',
-                              amount: {
-                                value: 200,
-                                offset: 100
-                              },
-                              quantity: 1
-                            }
-                          ],
-                          subtotal: {
-                            value: 200,
-                            offset: 100
-                          }
-                        }
-                      }
-                    },
-                    type: 'action'
-                  }
-                ]
-              }
-            ]
-          },
-          templateContent: {
-            name: 'teste_payments_1',
-            language: 'pt_BR',
-            components: [
-              {
-                type: 'BODY',
-                text: 'Olá.\\nSegue para pagamento.'
-              },
-              {
-                type: 'BUTTONS',
-                buttons: [
-                  {
-                    type: 'ORDER_DETAILS',
-                    text: 'Copy Pix code'
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      })
-      this.send()
-    },
-    sendTemplateOrderDocument: function() {
-      this.json = JSON.stringify({
-        id: '16b0d902-7487-4c5c-b49c-8103558621e7',
-        direction: 'sent',
-        type: 'template',
-        content: {
-          type: 'template-content',
-          template: {
-            language: {
-              policy: 'deterministic',
-              code: 'pt_BR'
-            },
-            name: 'teste_payments_1',
-            components: [
-              {
-                type: 'header',
-                parameters: [
-                  {
-                    document: {
-                      filename: 'dummy',
-                      link:
-                        'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf'
-                    },
-                    type: 'document'
-                  }
-                ]
-              },
-              {
-                sub_type: 'order_details',
-                index: '0',
-                type: 'button',
-                parameters: [
-                  {
-                    action: {
-                      order_details: {
-                        reference_id: '1234567',
-                        type: 'digital-goods',
-                        payment_type: 'br',
-                        payment_settings: [
-                          {
-                            type: 'pix_dynamic_code',
-                            pix_dynamic_code: {
-                              code:
-                                '00020126580014BR.GOV.BCB.PIX0136dda1eb4e-744f-4453-8074-a0ab5ffed3d85204000053039865802BR5921Gabriel Felix Petrone6009SAO PAULO62140510sF9EEKoAp56304AB67',
-                              merchant_name: 'Gabriel Petrone',
-                              key: 'gabriel.petrone@blip.ai',
-                              key_type: 'EMAIL'
-                            }
-                          }
-                        ],
-                        currency: 'BRL',
-                        total_amount: {
-                          value: 200,
-                          offset: 100
-                        },
-                        order: {
-                          status: 'pending',
-                          tax: {
-                            value: 0,
-                            offset: 100
-                          },
-                          items: [
-                            {
-                              retailer_id: '1234567',
-                              name: 'Presente Misterioso',
-                              amount: {
-                                value: 200,
-                                offset: 100
-                              },
-                              quantity: 1
-                            }
-                          ],
-                          subtotal: {
-                            value: 200,
-                            offset: 100
-                          }
-                        }
-                      }
-                    },
-                    type: 'action'
-                  }
-                ]
-              }
-            ]
-          },
-          templateContent: {
-            name: 'teste_payments_1',
-            language: 'pt_BR',
-            components: [
-              {
-                type: 'HEADER',
-                format: 'DOCUMENT',
-                example: {
-                  headerHandle: [
-                    'https://scontent.whatsapp.net/v/t61.29466-34/521274600_1869416363990860_4813441808641739597_n.pdf?ccb=1-7&_nc_sid=8b1bef&_nc_ohc=kaksJtUbzi4Q7kNvwFw_zUr&_nc_oc=Adn2h-Jk3rnqcup4orFp2edi06A0NqP9uAAtbs0d4Z_kQCizPy5p-2ewNG6m9l6gMHk&_nc_zt=3&_nc_ht=scontent.whatsapp.net&edm=AH51TzQEAAAA&_nc_gid=wqTRTF902E_ymJUSdLV9SA&oh=01_Q5Aa2QGc3jvj7DYE-q1HumUpl1rl2vY0g-yGhZ02Fu_yO02ksQ&oe=68DFDDE9'
-                  ]
-                }
-              },
-              {
-                type: 'BODY',
-                text: 'Olá.\\nSegue para pagamento.'
-              },
-              {
-                type: 'BUTTONS',
-                buttons: [
-                  {
-                    type: 'ORDER_DETAILS',
-                    text: 'Copy Pix code'
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      })
-      this.send()
-    },
-    sendTemplateOrderImage: function() {
-      this.json = JSON.stringify({
-        id: '16b0d902-7487-4c5c-b49c-8103558621e7',
-        direction: 'sent',
-        type: 'template',
-        content: {
-          type: 'template-content',
-          template: {
-            name: 'teste_payments_1',
-            language: {
-              policy: 'deterministic',
-              code: 'pt_BR'
-            },
-            components: [
-              {
-                type: 'header',
-                parameters: [
-                  {
-                    type: 'image',
-                    image: {
-                      link: 'https://s3-sa-east-1.amazonaws.com/msging.net/iris/Media_ee3797dd-c943-4fd8-bddb-c3cf89d5fbfd'
-                    }
-                  }
-                ]
-              },
-              {
-                type: 'button',
-                sub_type: 'order_details',
-                index: '0',
-                parameters: [
-                  {
-                    type: 'action',
-                    action: {
-                      order_details: {
-                        reference_id: '1234567',
-                        type: 'digital-goods',
-                        payment_type: 'br',
-                        payment_settings: [
-                          {
-                            type: 'pix_dynamic_code',
-                            pix_dynamic_code: {
-                              code:
-                                '00020126580014BR.GOV.BCB.PIX0136dda1eb4e-744f-4453-8074-a0ab5ffed3d85204000053039865802BR5921Gabriel Felix Petrone6009SAO PAULO62140510sF9EEKoAp56304AB67',
-                              merchant_name: 'Gabriel Petrone',
-                              key: 'gabriel.petrone@blip.ai',
-                              key_type: 'EMAIL'
-                            }
-                          }
-                        ],
-                        currency: 'BRL',
-                        total_amount: {
-                          value: 200,
-                          offset: 100
-                        },
-                        order: {
-                          status: 'pending',
-                          tax: {
-                            value: 0,
-                            offset: 100
-                          },
-                          items: [
-                            {
-                              retailer_id: '1234567',
-                              name: 'Presente Misterioso',
-                              amount: {
-                                value: 200,
-                                offset: 100
-                              },
-                              quantity: 1
-                            }
-                          ],
-                          subtotal: {
-                            value: 200,
-                            offset: 100
-                          }
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          templateContent: {
-            name: 'teste_payments_1',
-            language: 'pt_BR',
-            components: [
-              {
-                type: 'HEADER',
-                format: 'IMAGE',
-                example: {
-                  headerHandle: [
-                    'https://s3-sa-east-1.amazonaws.com/msging.net/iris/Media_ee3797dd-c943-4fd8-bddb-c3cf89d5fbfd'
-                  ]
-                }
-              },
-              {
-                type: 'BODY',
-                text: 'Olá.\\nSegue para pagamento.'
-              },
-              {
-                type: 'BUTTONS',
-                buttons: [
-                  {
-                    type: 'ORDER_DETAILS',
-                    text: 'Copy Pix code'
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      })
-      this.send()
-    },
     sendReplyDeletedMessage: function() {
       this.json = JSON.stringify({
         id: 'b1c3398f-ef63-426d-98b8-37ca84478f8f',
@@ -2139,7 +1296,7 @@ export default {
           inReplyTo: {
             id: 'b1c3398f-ef63-426d-98b8-37ca84478f8f',
             type: 'application/vnd.lime.deleted-content+json',
-            value: {}
+            value: { }
           }
         }
       })
@@ -2181,8 +1338,7 @@ export default {
             type: 'application/vnd.lime.media-link+json',
             value: {
               type: 'image/jpeg',
-              title:
-                'texto de exemplo texto de exemplo texto de exemplo texto de exemplo texto de exemplo texto de exemplo texto de exemplo texto de exemplo',
+              title: 'texto de exemplo texto de exemplo texto de exemplo texto de exemplo texto de exemplo texto de exemplo texto de exemplo texto de exemplo',
               uri:
                 'http://2.bp.blogspot.com/-pATX0YgNSFs/VP-82AQKcuI/AAAAAAAALSU/Vet9e7Qsjjw/s1600/Cat-hd-wallpapers.jpg'
             },
@@ -2453,8 +1609,7 @@ export default {
             type: 'application/vnd.lime.media-link+json',
             value: {
               type: 'audio/mp3',
-              uri:
-                'https://upload.wikimedia.org/wikipedia/commons/6/63/Sagetyrtle_-_citystreet3_%28cc0%29_%28freesound%29.mp3'
+              uri: 'https://upload.wikimedia.org/wikipedia/commons/6/63/Sagetyrtle_-_citystreet3_%28cc0%29_%28freesound%29.mp3'
             }
           },
           inReplyTo: {

--- a/src/components/ApplicationJSon.vue
+++ b/src/components/ApplicationJSon.vue
@@ -81,6 +81,15 @@
       :editing="editing"
     />
 
+    <component-order
+      v-else-if="document.type === 'interactive' && document.interactive.type === 'order_details'"
+      class="blip-card"
+      :document="document"
+      :position="position"
+      :status="status"
+      :readonly="true"
+    />
+
     <blip-calls-voice-request
       v-else-if="document.type === 'interactive' && document.interactive.type === 'voice_call'"
       class="blip-card"
@@ -136,6 +145,7 @@ import { isFailedMessage } from '../utils/misc'
 import MenuListPrompt from './ApplicationJSon/MenuListPrompt.vue'
 import CallToAction from './ApplicationJSon/CallToAction.vue'
 import JsonText from './ApplicationJSon/JsonText.vue'
+import ComponentOrder from './ApplicationJSon/ComponentOrder.vue'
 
 export default {
   name: 'application-json',
@@ -178,7 +188,8 @@ export default {
     MenuList,
     MenuListPrompt,
     CallToAction,
-    JsonText
+    JsonText,
+    ComponentOrder
   },
   methods: {
     emitUpdate() {

--- a/src/components/ApplicationJSon/ComponentOrder.vue
+++ b/src/components/ApplicationJSon/ComponentOrder.vue
@@ -256,7 +256,7 @@ export default {
           this.document.interactive.header &&
           this.document.interactive.header.image &&
           this.document.interactive.header.image.link) ||
-        'https://placehold.co/50'
+        'https://placehold.co/40'
       )
     },
     documentName() {

--- a/src/components/ApplicationJSon/ComponentOrder.vue
+++ b/src/components/ApplicationJSon/ComponentOrder.vue
@@ -1,0 +1,602 @@
+<template>
+  <div v-if="!isEditing" class="blip-container component-order">
+    <div :class="isFailedMessage(status, position)">
+      <div :class="'bubble ' + position">
+        <bds-button-icon
+          v-if="deletable && !isEditing"
+          class="editIco trashIco icon-margin"
+          icon="trash"
+          variant="delete"
+          size="short"
+          v-on:click="trash(document)"
+        ></bds-button-icon>
+        <bds-button-icon
+          v-if="editable && !isEditing"
+          class="editIco icon-margin"
+          icon="edit"
+          variant="primary"
+          size="short"
+          v-on:click="toggleEdit"
+        ></bds-button-icon>
+
+        <!-- Header Section -->
+        <bds-grid v-if="hasDocumentHeader" direction="column" padding="x-2">
+          <bds-paper
+            elevation="static"
+            class="mt-card__payment-block__paper-document"
+          >
+            <bds-grid
+              padding="1"
+              direction="row"
+              gap="1"
+              justify-content="flex-start"
+              align-items="center"
+            >
+              <bds-icon
+                theme="outline"
+                name="file-pdf"
+                size="small"
+                type="icon"
+                class="icon-pdf"
+              ></bds-icon>
+              <bds-typo variant="fs-10" bold="bold" line-height="small">
+                {{ documentName }}
+              </bds-typo>
+            </bds-grid>
+          </bds-paper>
+        </bds-grid>
+
+        <!-- Main Content -->
+        <bds-grid direction="column" padding="2">
+          <bds-paper
+            elevation="static"
+            class="mt-card__payment-block__paper-content"
+          >
+            <bds-grid padding="2" direction="column">
+              <bds-typo variant="fs-10">{{ orderTitle }}</bds-typo>
+              <div class="divider" />
+
+              <!-- Items -->
+              <bds-grid
+                v-if="itemsDisplay.single"
+                justify-content="flex-start"
+                align-items="center"
+                direction="row"
+                gap="1"
+              >
+                <img
+                  v-if="hasImageHeader"
+                  :src="headerImageUrl"
+                  alt="item"
+                  width="40"
+                  class="image-payment"
+                />
+                <div>
+                  <bds-typo variant="fs-12" bold="bold">{{
+                    itemsDisplay.name
+                  }}</bds-typo>
+                  <bds-typo variant="fs-10" class="content-color-ghost">{{
+                    formatQuantity(itemsDisplay.quantity)
+                  }}</bds-typo>
+                </div>
+              </bds-grid>
+
+              <bds-grid
+                v-else
+                justify-content="flex-start"
+                align-items="center"
+                direction="row"
+                gap="1"
+              >
+                <img
+                  v-if="hasImageHeader"
+                  :src="headerImageUrl"
+                  alt="items"
+                  width="40"
+                  class="image-payment"
+                />
+                <div>
+                  <bds-typo variant="fs-12" bold="bold">{{
+                    itemsDisplay.names
+                  }}</bds-typo>
+                  <bds-typo variant="fs-10" class="content-color-ghost">{{
+                    formatItemsCount(itemsDisplay.totalItems)
+                  }}</bds-typo>
+                </div>
+              </bds-grid>
+
+              <div class="divider" />
+
+              <!-- Payment Methods -->
+              <bds-grid justify-content="space-between" align-items="center">
+                <bds-typo variant="fs-12" bold="bold">{{
+                  paymentMethodsLabel
+                }}</bds-typo>
+                <div>
+                  <bds-icon
+                    v-for="icon in paymentIcons"
+                    :key="icon"
+                    class="content-color-ghost"
+                    :theme="getIconTheme(icon)"
+                    :name="icon"
+                    size="small"
+                  ></bds-icon>
+                </div>
+              </bds-grid>
+
+              <div class="divider" />
+
+              <!-- Total -->
+              <bds-grid justify-content="space-between" align-items="center">
+                <bds-typo variant="fs-12">Total</bds-typo>
+                <bds-typo variant="fs-12" bold="bold">{{
+                  formattedTotal
+                }}</bds-typo>
+              </bds-grid>
+            </bds-grid>
+          </bds-paper>
+        </bds-grid>
+        <!-- Text Content -->
+        <bds-grid direction="column" gap="1" padding="x-2">
+          <!-- Header Text -->
+          <bds-grid
+            v-if="hasTextHeader"
+            justify-content="space-between"
+            align-items="center"
+          >
+            <bds-typo variant="fs-14" bold="bold">{{ headerText }}</bds-typo>
+          </bds-grid>
+
+          <!-- Body Text -->
+          <bds-grid justify-content="space-between" align-items="center">
+            <bds-typo variant="fs-14" style="white-space: pre-line;">{{
+              bodyText
+            }}</bds-typo>
+          </bds-grid>
+
+          <!-- Footer Text -->
+          <bds-grid
+            v-if="footerText"
+            justify-content="space-between"
+            align-items="center"
+          >
+            <bds-typo variant="fs-12" class="color-footer-disable">{{
+              footerText
+            }}</bds-typo>
+          </bds-grid>
+        </bds-grid>
+
+        <div class="divider" />
+        <!-- Payment Action Buttons -->
+        <bds-grid padding="x-2" gap="1" direction="column">
+          <bds-grid
+            v-for="button in paymentButtons"
+            :key="button.type"
+            direction="row"
+            align-items="center"
+            justify-content="center"
+            class="button-container payment-button"
+            gap="1"
+            @click="handlePaymentAction(button)"
+          >
+            <bds-icon
+              :name="button.icon"
+              :class="
+                'button-container-text-' +
+                  (position == 'right' ? 'white' : 'primary')
+              "
+            ></bds-icon>
+            <bds-typo
+              :class="
+                'button-container-text-' +
+                  (position == 'right' ? 'white' : 'primary')
+              "
+              >{{ button.text }}</bds-typo
+            >
+          </bds-grid>
+        </bds-grid>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { default as base } from '../../mixins/baseComponent.js'
+import { isFailedMessage } from '../../utils/misc'
+
+export default {
+  name: 'component-order',
+  mixins: [base],
+  props: {
+    status: {
+      type: String,
+      default: ''
+    },
+    readonly: {
+      type: Boolean,
+      default: false
+    },
+    position: {
+      type: String,
+      default: 'right'
+    }
+  },
+  data: function() {
+    return {
+      headerText: '',
+      bodyText: '',
+      footerText: '',
+      isFailedMessage
+    }
+  },
+  computed: {
+    hasTextHeader() {
+      return (
+        this.document &&
+        this.document.interactive &&
+        this.document.interactive.header &&
+        this.document.interactive.header.type === 'text'
+      )
+    },
+    hasImageHeader() {
+      return (
+        this.document &&
+        this.document.interactive &&
+        this.document.interactive.header &&
+        this.document.interactive.header.type === 'image'
+      )
+    },
+    hasDocumentHeader() {
+      return (
+        this.document &&
+        this.document.interactive &&
+        this.document.interactive.header &&
+        this.document.interactive.header.type === 'document'
+      )
+    },
+    headerImageUrl() {
+      return (
+        (this.document &&
+          this.document.interactive &&
+          this.document.interactive.header &&
+          this.document.interactive.header.image &&
+          this.document.interactive.header.image.link) ||
+        'https://via.placeholder.com/40'
+      )
+    },
+    documentName() {
+      return (
+        (this.document &&
+          this.document.interactive &&
+          this.document.interactive.header &&
+          this.document.interactive.header.document &&
+          this.document.interactive.header.document.filename) ||
+        'Documento'
+      )
+    },
+    orderItems() {
+      const items =
+        (this.document &&
+          this.document.interactive &&
+          this.document.interactive.action &&
+          this.document.interactive.action.parameters &&
+          this.document.interactive.action.parameters.order &&
+          this.document.interactive.action.parameters.order.items) ||
+        []
+      return items.length > 0 ? items : [{ name: 'Item exemplo', quantity: 1 }]
+    },
+    itemsDisplay() {
+      const items = this.orderItems
+      if (items.length === 1) {
+        const itemName = items[0].name
+        return {
+          single: true,
+          name:
+            itemName.length > 40 ? itemName.substring(0, 40) + '...' : itemName,
+          quantity: items[0].quantity
+        }
+      } else {
+        const allNames = items.map((item) => item.name).join(', ')
+        return {
+          single: false,
+          names:
+            allNames.length > 40 ? allNames.substring(0, 40) + '...' : allNames,
+          totalItems: items.length
+        }
+      }
+    },
+    orderTitle() {
+      const referenceId =
+        (this.document &&
+          this.document.interactive &&
+          this.document.interactive.action &&
+          this.document.interactive.action.parameters &&
+          this.document.interactive.action.parameters.reference_id) ||
+        '000000'
+      return `Número da cobrança: ${referenceId}`
+    },
+    formattedTotal() {
+      const total =
+        this.document &&
+        this.document.interactive &&
+        this.document.interactive.action &&
+        this.document.interactive.action.parameters &&
+        this.document.interactive.action.parameters.total_amount
+      if (total) {
+        const value = total.value / (total.offset || 100)
+        return `R$ ${value.toFixed(2).replace('.', ',')}`
+      }
+      return 'R$ 0,00'
+    },
+    paymentIcons() {
+      const settings =
+        (this.document &&
+          this.document.interactive &&
+          this.document.interactive.action &&
+          this.document.interactive.action.parameters &&
+          this.document.interactive.action.parameters.payment_settings) ||
+        []
+      const icons = []
+
+      settings.forEach((setting) => {
+        switch (setting.type) {
+          case 'pix_dynamic_code':
+            icons.push('pix')
+            break
+          case 'boleto':
+            icons.push('barcode')
+            break
+          case 'payment_link':
+            icons.push('payment-card')
+            break
+        }
+      })
+
+      return icons.length > 0 ? icons : ['pix', 'barcode', 'payment-card']
+    },
+    paymentMethodsLabel() {
+      return 'Pagar com'
+    },
+    paymentButtons() {
+      const settings =
+        (this.document &&
+          this.document.interactive &&
+          this.document.interactive.action &&
+          this.document.interactive.action.parameters &&
+          this.document.interactive.action.parameters.payment_settings) ||
+        []
+
+      const buttons = []
+
+      settings.forEach((setting) => {
+        switch (setting.type) {
+          case 'pix_dynamic_code':
+            buttons.push({
+              type: 'pix_dynamic_code',
+              text: 'Copiar Chave Pix',
+              icon: 'copy',
+              data: setting.pix_dynamic_code.code
+            })
+            break
+          case 'boleto':
+            buttons.push({
+              type: 'boleto',
+              text: 'Copiar Código do Boleto',
+              icon: 'copy',
+              data: setting.boleto.barcode
+            })
+            break
+          case 'payment_link':
+            buttons.push({
+              type: 'payment_link',
+              text: 'Abrir Link de Pagamento',
+              icon: 'external-file',
+              data: setting.payment_link.url
+            })
+            break
+        }
+      })
+
+      return buttons
+    },
+    actionButtonText() {
+      const actionName =
+        this.document &&
+        this.document.interactive &&
+        this.document.interactive.action &&
+        this.document.interactive.action.name
+      switch (actionName) {
+        case 'review_and_pay':
+          return 'Revisar e Pagar'
+        default:
+          return 'Finalizar Pedido'
+      }
+    }
+  },
+  methods: {
+    init: function() {
+      this.headerText =
+        (this.document &&
+          this.document.interactive &&
+          this.document.interactive.header &&
+          this.document.interactive.header.text) ||
+        ''
+      this.bodyText =
+        (this.document &&
+          this.document.interactive &&
+          this.document.interactive.body &&
+          this.document.interactive.body.text) ||
+        ''
+      this.footerText =
+        (this.document &&
+          this.document.interactive &&
+          this.document.interactive.footer &&
+          this.document.interactive.footer.text) ||
+        ''
+    },
+    formatQuantity(quantity) {
+      return `Quantidade: ${quantity}`
+    },
+    formatItemsCount(count) {
+      return `${count} ${count === 1 ? 'item' : 'itens'}`
+    },
+    getIconTheme(iconName) {
+      return iconName === 'pix' ? 'solid' : 'outline'
+    },
+    handlePaymentAction(button) {
+      switch (button.type) {
+        case 'pix_dynamic_code':
+        case 'boleto':
+          this.copyToClipboard(button.data, button.text)
+          break
+        case 'payment_link':
+          window.open(button.data, '_blank', 'noopener,noreferrer')
+          break
+      }
+    },
+    copyToClipboard(text, buttonText) {
+      if (navigator.clipboard && window.isSecureContext) {
+        // Usar a API moderna do clipboard
+        navigator.clipboard
+          .writeText(text)
+          .then(() => {
+            this.showCopySuccess(buttonText)
+          })
+          .catch(() => {
+            this.fallbackCopyToClipboard(text, buttonText)
+          })
+      } else {
+        // Fallback para navegadores mais antigos
+        this.fallbackCopyToClipboard(text, buttonText)
+      }
+    },
+    fallbackCopyToClipboard(text, buttonText) {
+      const textArea = document.createElement('textarea')
+      textArea.value = text
+      textArea.style.position = 'fixed'
+      textArea.style.opacity = '0'
+      document.body.appendChild(textArea)
+      textArea.select()
+
+      try {
+        document.execCommand('copy')
+        this.showCopySuccess(buttonText)
+      } catch (err) {
+        console.error('Erro ao copiar:', err)
+      }
+
+      document.body.removeChild(textArea)
+    },
+    showCopySuccess(buttonText) {
+      // Aqui você pode adicionar uma notificação de sucesso
+      console.log(`${buttonText} copiado com sucesso!`)
+      // Exemplo: mostrar toast, alterar temporariamente o texto do botão, etc.
+    },
+    orderSave: function($event) {
+      if (this.errors.any() || ($event && $event.shiftKey)) {
+        return
+      }
+
+      this.$validator.validateAll().then((result) => {
+        if (!result) return
+
+        if (this.document.interactive.header) {
+          this.save({
+            ...this.document.interactive.header,
+            text: this.headerText
+          })
+        }
+
+        this.save({
+          ...this.document.interactive.body,
+          text: this.bodyText
+        })
+
+        if (this.document.interactive.footer) {
+          this.save({
+            ...this.document.interactive.footer,
+            text: this.footerText
+          })
+        }
+      })
+    },
+    orderEditCancel: function() {
+      this.cancel()
+    }
+  },
+  updated: function() {
+    this.$emit('updated')
+  }
+}
+</script>
+
+<style scoped lang="scss">
+@import '../../styles/variables.scss';
+
+.component-order {
+  .divider {
+    border-top: 1px dashed $color-surface-3;
+    margin-top: 8px;
+    margin-bottom: 8px;
+    width: 100%;
+  }
+
+  .payment-button {
+    margin: 0;
+    &:not(:last-child) {
+      border-bottom: 1px solid $color-surface-3;
+      border-radius: 0;
+    }
+  }
+
+  .bubble {
+    padding: $bubble-padding;
+    padding-left: 0px;
+    padding-right: 0px;
+    min-width: 206px;
+    text-align: left;
+    max-width: 340px;
+  }
+}
+
+.mt-card__payment-block__paper-document {
+  .icon-pdf {
+    color: #d32f2f;
+  }
+}
+
+.mt-card__payment-block__paper-content {
+  background-color: $color-surface-2;
+  .image-payment {
+    border-radius: 4px;
+    object-fit: cover;
+  }
+}
+
+.color-footer-disable {
+  color: $color-content-ghost;
+}
+
+.content-color-ghost {
+  color: $color-content-ghost;
+}
+
+.blip-card .form-group .help {
+  padding: 0px;
+}
+
+.button-container {
+  width: 100%;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+.button-container-text-primary {
+  color: $color-primary;
+}
+
+.button-container-text-white {
+  color: $color-surface-1;
+}
+
+</style>

--- a/src/components/ApplicationJSon/ComponentOrder.vue
+++ b/src/components/ApplicationJSon/ComponentOrder.vue
@@ -23,7 +23,7 @@
         <bds-grid v-if="hasDocumentHeader" direction="column" padding="x-2">
           <bds-paper
             elevation="static"
-            class="mt-card__payment-block__paper-document"
+            class="payment-component-order__paper-document"
           >
             <bds-grid
               padding="1"
@@ -56,7 +56,6 @@
               <bds-typo variant="fs-10">{{ orderTitle }}</bds-typo>
               <div class="divider" />
 
-              <!-- Items -->
               <bds-grid
                 v-if="itemsDisplay.single"
                 justify-content="flex-start"
@@ -107,7 +106,6 @@
 
               <div class="divider" />
 
-              <!-- Payment Methods -->
               <bds-grid justify-content="space-between" align-items="center">
                 <bds-typo variant="fs-12" bold="bold">{{
                   paymentMethodsLabel
@@ -126,7 +124,6 @@
 
               <div class="divider" />
 
-              <!-- Total -->
               <bds-grid justify-content="space-between" align-items="center">
                 <bds-typo variant="fs-12">Total</bds-typo>
                 <bds-typo variant="fs-12" bold="bold">{{
@@ -136,7 +133,6 @@
             </bds-grid>
           </bds-paper>
         </bds-grid>
-        <!-- Text Content -->
         <bds-grid direction="column" gap="1" padding="x-2">
           <!-- Header Text -->
           <bds-grid
@@ -147,14 +143,12 @@
             <bds-typo variant="fs-14" bold="bold">{{ headerText }}</bds-typo>
           </bds-grid>
 
-          <!-- Body Text -->
           <bds-grid justify-content="space-between" align-items="center">
             <bds-typo variant="fs-14" style="white-space: pre-line;">{{
               bodyText
             }}</bds-typo>
           </bds-grid>
 
-          <!-- Footer Text -->
           <bds-grid
             v-if="footerText"
             justify-content="space-between"
@@ -167,7 +161,7 @@
         </bds-grid>
 
         <div class="divider" />
-        <!-- Payment Action Buttons -->
+
         <bds-grid padding="x-2" gap="1" direction="column">
           <bds-grid
             v-for="button in paymentButtons"
@@ -203,6 +197,7 @@
 <script>
 import { default as base } from '../../mixins/baseComponent.js'
 import { isFailedMessage } from '../../utils/misc'
+import { ComponentOrderType, ComponentOrderPaymentType, ComponentOrderIcon } from '../../enums/componentOrder.enum.js'
 
 export default {
   name: 'component-order',
@@ -235,7 +230,7 @@ export default {
         this.document &&
         this.document.interactive &&
         this.document.interactive.header &&
-        this.document.interactive.header.type === 'text'
+        this.document.interactive.header.type === ComponentOrderType.TEXT
       )
     },
     hasImageHeader() {
@@ -243,7 +238,7 @@ export default {
         this.document &&
         this.document.interactive &&
         this.document.interactive.header &&
-        this.document.interactive.header.type === 'image'
+        this.document.interactive.header.type === ComponentOrderType.IMAGE
       )
     },
     hasDocumentHeader() {
@@ -251,7 +246,7 @@ export default {
         this.document &&
         this.document.interactive &&
         this.document.interactive.header &&
-        this.document.interactive.header.type === 'document'
+        this.document.interactive.header.type === ComponentOrderType.DOCUMENT
       )
     },
     headerImageUrl() {
@@ -261,7 +256,7 @@ export default {
           this.document.interactive.header &&
           this.document.interactive.header.image &&
           this.document.interactive.header.image.link) ||
-        'https://via.placeholder.com/40'
+        'https://placehold.co/50'
       )
     },
     documentName() {
@@ -340,19 +335,19 @@ export default {
 
       settings.forEach((setting) => {
         switch (setting.type) {
-          case 'pix_dynamic_code':
-            icons.push('pix')
+          case ComponentOrderPaymentType.PIX_DYNAMIC_CODE:
+            icons.push(ComponentOrderIcon.PIX)
             break
-          case 'boleto':
-            icons.push('barcode')
+          case ComponentOrderPaymentType.BOLETO:
+            icons.push(ComponentOrderIcon.BARCODE)
             break
-          case 'payment_link':
-            icons.push('payment-card')
+          case ComponentOrderPaymentType.PAYMENT_LINK:
+            icons.push(ComponentOrderIcon.PAYMENT_CARD)
             break
         }
       })
 
-      return icons.length > 0 ? icons : ['pix', 'barcode', 'payment-card']
+      return icons.length > 0 ? icons : [ComponentOrderIcon.PIX, ComponentOrderIcon.BARCODE, ComponentOrderIcon.PAYMENT_CARD]
     },
     paymentMethodsLabel() {
       return 'Pagar com'
@@ -370,27 +365,27 @@ export default {
 
       settings.forEach((setting) => {
         switch (setting.type) {
-          case 'pix_dynamic_code':
+          case ComponentOrderPaymentType.PIX_DYNAMIC_CODE:
             buttons.push({
-              type: 'pix_dynamic_code',
+              type: ComponentOrderPaymentType.PIX_DYNAMIC_CODE,
               text: 'Copiar Chave Pix',
-              icon: 'copy',
+              icon: ComponentOrderIcon.COPY,
               data: setting.pix_dynamic_code.code
             })
             break
-          case 'boleto':
+          case ComponentOrderPaymentType.BOLETO:
             buttons.push({
-              type: 'boleto',
+              type: ComponentOrderPaymentType.BOLETO,
               text: 'Copiar Código do Boleto',
-              icon: 'copy',
+              icon: ComponentOrderIcon.COPY,
               data: setting.boleto.barcode
             })
             break
-          case 'payment_link':
+          case ComponentOrderPaymentType.PAYMENT_LINK:
             buttons.push({
-              type: 'payment_link',
+              type: ComponentOrderPaymentType.PAYMENT_LINK,
               text: 'Abrir Link de Pagamento',
-              icon: 'external-file',
+              icon: ComponentOrderIcon.EXTERNAL_FILE,
               data: setting.payment_link.url
             })
             break
@@ -414,25 +409,32 @@ export default {
     }
   },
   methods: {
+    processText: function(text) {
+      if (!text) return ''
+      return text.replace(/\\\\n/g, '\n').replace(/\\n/g, '\n')
+    },
     init: function() {
-      this.headerText =
+      const rawHeaderText =
         (this.document &&
           this.document.interactive &&
           this.document.interactive.header &&
           this.document.interactive.header.text) ||
         ''
-      this.bodyText =
+      const rawBodyText =
         (this.document &&
           this.document.interactive &&
           this.document.interactive.body &&
           this.document.interactive.body.text) ||
         ''
-      this.footerText =
+      const rawFooterText =
         (this.document &&
           this.document.interactive &&
           this.document.interactive.footer &&
           this.document.interactive.footer.text) ||
         ''
+      this.headerText = this.processText(rawHeaderText)
+      this.bodyText = this.processText(rawBodyText)
+      this.footerText = this.processText(rawFooterText)
     },
     formatQuantity(quantity) {
       return `Quantidade: ${quantity}`
@@ -456,17 +458,9 @@ export default {
     },
     copyToClipboard(text, buttonText) {
       if (navigator.clipboard && window.isSecureContext) {
-        // Usar a API moderna do clipboard
         navigator.clipboard
           .writeText(text)
-          .then(() => {
-            this.showCopySuccess(buttonText)
-          })
-          .catch(() => {
-            this.fallbackCopyToClipboard(text, buttonText)
-          })
       } else {
-        // Fallback para navegadores mais antigos
         this.fallbackCopyToClipboard(text, buttonText)
       }
     },
@@ -480,17 +474,11 @@ export default {
 
       try {
         document.execCommand('copy')
-        this.showCopySuccess(buttonText)
       } catch (err) {
         console.error('Erro ao copiar:', err)
       }
 
       document.body.removeChild(textArea)
-    },
-    showCopySuccess(buttonText) {
-      // Aqui você pode adicionar uma notificação de sucesso
-      console.log(`${buttonText} copiado com sucesso!`)
-      // Exemplo: mostrar toast, alterar temporariamente o texto do botão, etc.
     },
     orderSave: function($event) {
       if (this.errors.any() || ($event && $event.shiftKey)) {
@@ -553,13 +541,16 @@ export default {
     padding: $bubble-padding;
     padding-left: 0px;
     padding-right: 0px;
-    min-width: 206px;
+    min-width: 210px;
     text-align: left;
-    max-width: 340px;
+    width: 290px;
+    max-width: 90%;
   }
 }
 
-.mt-card__payment-block__paper-document {
+.payment-component-order__paper-document {
+  margin-bottom: -10px !important;
+  border-radius: 6px;
   .icon-pdf {
     color: #d32f2f;
   }

--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -426,8 +426,17 @@
           :date="date"
         />
 
+        <template-order
+          v-else-if="document.content.type === 'template-content' && isTemplateWithOrderDetails"
+          class="blip-card"
+          :status="status"
+          :position="position"
+          :document="editableDocument.content"
+          :readonly="true"
+        />
+
         <template-content
-          v-else-if="document.content.type === 'template-content'"
+          v-else-if="document.content.type === 'template-content'  && !isTemplateWithOrderDetails"
           class="blip-card"
           :failed-to-send-msg="translations.failedToSend"
           :message-template-title="translations.messageTemplate ? translations.messageTemplate + document.content.template.name : translations.unsupportedContent"
@@ -446,15 +455,6 @@
           :on-cancel="cancel"
           :disable-link="disableLink"
           :reply-callback="replyCallback"
-        />
-
-        <template-order
-          v-else-if="document.content.type === 'template' && isTemplateWithOrderDetails"
-          class="blip-card"
-          :status="status"
-          :position="position"
-          :document="editableDocument.content"
-          :readonly="true"
         />
 
         <unsuported-content
@@ -901,7 +901,7 @@ export default {
       return getMemberInfo(this.document)
     },
     isTemplateWithOrderDetails() {
-      if (!this.document || !this.document.content || this.document.content.type !== 'template') return false
+      if (!this.document || !this.document.content || this.document.content.type !== 'template-content') return false
 
       const components = (this.document.content.template && this.document.content.template.components) || []
       return components.some(comp =>

--- a/src/components/BlipCard.vue
+++ b/src/components/BlipCard.vue
@@ -448,6 +448,15 @@
           :reply-callback="replyCallback"
         />
 
+        <template-order
+          v-else-if="document.content.type === 'template' && isTemplateWithOrderDetails"
+          class="blip-card"
+          :status="status"
+          :position="position"
+          :document="editableDocument.content"
+          :readonly="true"
+        />
+
         <unsuported-content
           v-else-if="document.content.type === 'template'"
           class="blip-card"
@@ -714,6 +723,7 @@ import { default as base } from '../mixins/baseComponent.js'
 import { MessageTypesConstants } from '../utils/MessageTypesConstants.js'
 import { checkIsExternalMessage } from '../utils/externalMessages.js'
 import { getMemberInfo } from '../utils/memberUtils.js'
+import TemplateOrder from './TemplateContent/TemplateOrder.vue'
 
 const supportedRepliedTypes = [
   MessageTypesConstants.TEXT_MESSAGE,
@@ -889,7 +899,19 @@ export default {
     },
     memberInfo() {
       return getMemberInfo(this.document)
+    },
+    isTemplateWithOrderDetails() {
+      if (!this.document || !this.document.content || this.document.content.type !== 'template') return false
+
+      const components = (this.document.content.template && this.document.content.template.components) || []
+      return components.some(comp =>
+        comp.type === 'button' &&
+        comp.sub_type === 'order_details'
+      )
     }
+  },
+  components: {
+    TemplateOrder
   }
 }
 </script>

--- a/src/components/TemplateContent/TemplateOrder.vue
+++ b/src/components/TemplateContent/TemplateOrder.vue
@@ -1,0 +1,618 @@
+<template>
+  <div v-if="!isEditing" class="blip-container template-order">
+    <div :class="isFailedMessage(status, position)">
+      <div :class="'bubble ' + position">
+        <bds-button-icon
+          v-if="deletable && !isEditing"
+          class="editIco trashIco icon-margin"
+          icon="trash"
+          variant="delete"
+          size="short"
+          v-on:click="trash(document)"
+        ></bds-button-icon>
+        <bds-button-icon
+          v-if="editable && !isEditing"
+          class="editIco icon-margin"
+          icon="edit"
+          variant="primary"
+          size="short"
+          v-on:click="toggleEdit"
+        ></bds-button-icon>
+
+        <!-- Header Section -->
+        <bds-grid v-if="hasDocumentHeader" direction="column" padding="x-2">
+          <bds-paper
+            elevation="static"
+            class="mt-card__payment-block__paper-document"
+          >
+            <bds-grid
+              padding="1"
+              direction="row"
+              gap="1"
+              justify-content="flex-start"
+              align-items="center"
+            >
+              <bds-icon
+                theme="outline"
+                name="file-pdf"
+                size="small"
+                type="icon"
+                class="icon-pdf"
+              ></bds-icon>
+              <bds-typo variant="fs-10" bold="bold" line-height="small">
+                {{ documentName }}
+              </bds-typo>
+            </bds-grid>
+          </bds-paper>
+        </bds-grid>
+
+        <!-- Main Content -->
+        <bds-grid direction="column" padding="2">
+          <bds-paper
+            elevation="static"
+            class="mt-card__payment-block__paper-content"
+          >
+            <bds-grid padding="2" direction="column">
+              <bds-typo variant="fs-10">{{ orderTitle }}</bds-typo>
+              <div class="divider" />
+
+              <!-- Items -->
+              <bds-grid
+                v-if="itemsDisplay.single"
+                justify-content="flex-start"
+                align-items="center"
+                direction="row"
+                gap="1"
+              >
+                <img
+                  v-if="hasImageHeader"
+                  :src="headerImageUrl"
+                  alt="item"
+                  width="40"
+                  class="image-payment"
+                />
+                <div>
+                  <bds-typo variant="fs-12" bold="bold">{{
+                    itemsDisplay.name
+                  }}</bds-typo>
+                  <bds-typo variant="fs-10" class="content-color-ghost">{{
+                    formatQuantity(itemsDisplay.quantity)
+                  }}</bds-typo>
+                </div>
+              </bds-grid>
+
+              <bds-grid
+                v-else
+                justify-content="flex-start"
+                align-items="center"
+                direction="row"
+                gap="1"
+              >
+                <img
+                  v-if="hasImageHeader"
+                  :src="headerImageUrl"
+                  alt="items"
+                  width="40"
+                  class="image-payment"
+                />
+                <div>
+                  <bds-typo variant="fs-12" bold="bold">{{
+                    itemsDisplay.names
+                  }}</bds-typo>
+                  <bds-typo variant="fs-10" class="content-color-ghost">{{
+                    formatItemsCount(itemsDisplay.totalItems)
+                  }}</bds-typo>
+                </div>
+              </bds-grid>
+
+              <div class="divider" />
+
+              <!-- Payment Methods -->
+              <bds-grid justify-content="space-between" align-items="center">
+                <bds-typo variant="fs-12" bold="bold">{{
+                  paymentMethodsLabel
+                }}</bds-typo>
+                <div>
+                  <bds-icon
+                    v-for="icon in paymentIcons"
+                    :key="icon"
+                    class="content-color-ghost"
+                    :theme="getIconTheme(icon)"
+                    :name="icon"
+                    size="small"
+                  ></bds-icon>
+                </div>
+              </bds-grid>
+
+              <div class="divider" />
+
+              <!-- Total -->
+              <bds-grid justify-content="space-between" align-items="center">
+                <bds-typo variant="fs-12">Total</bds-typo>
+                <bds-typo variant="fs-12" bold="bold">{{
+                  formattedTotal
+                }}</bds-typo>
+              </bds-grid>
+            </bds-grid>
+          </bds-paper>
+        </bds-grid>
+        <!-- Text Content -->
+        <bds-grid direction="column" gap="1" padding="x-2">
+          <!-- Header Text -->
+          <bds-grid
+            v-if="hasTextHeader"
+            justify-content="space-between"
+            align-items="center"
+          >
+            <bds-typo variant="fs-14" bold="bold">{{ headerText }}</bds-typo>
+          </bds-grid>
+
+          <!-- Body Text -->
+          <bds-grid justify-content="space-between" align-items="center">
+            <bds-typo variant="fs-14" style="white-space: pre-line;">{{
+              bodyText
+            }}</bds-typo>
+          </bds-grid>
+
+          <!-- Footer Text -->
+          <bds-grid
+            v-if="footerText"
+            justify-content="space-between"
+            align-items="center"
+          >
+            <bds-typo variant="fs-12" class="color-footer-disable">{{
+              footerText
+            }}</bds-typo>
+          </bds-grid>
+        </bds-grid>
+
+        <div class="divider" />
+        <!-- Payment Action Buttons -->
+        <bds-grid padding="x-2" gap="1" direction="column">
+          <bds-grid
+            v-for="button in paymentButtons"
+            :key="button.type"
+            direction="row"
+            align-items="center"
+            justify-content="center"
+            class="button-container payment-button"
+            gap="1"
+            @click="handlePaymentAction(button)"
+          >
+            <bds-icon
+              :name="button.icon"
+              :class="
+                'button-container-text-' +
+                  (position == 'right' ? 'white' : 'primary')
+              "
+            ></bds-icon>
+            <bds-typo
+              :class="
+                'button-container-text-' +
+                  (position == 'right' ? 'white' : 'primary')
+              "
+              >{{ button.text }}</bds-typo
+            >
+          </bds-grid>
+        </bds-grid>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { default as base } from '../../mixins/baseComponent.js'
+import { isFailedMessage } from '../../utils/misc'
+
+export default {
+  name: 'template-order',
+  mixins: [base],
+  props: {
+    status: {
+      type: String,
+      default: ''
+    },
+    readonly: {
+      type: Boolean,
+      default: false
+    },
+    position: {
+      type: String,
+      default: 'right'
+    }
+  },
+  data: function() {
+    return {
+      headerText: '',
+      bodyText: '',
+      footerText: '',
+      isFailedMessage
+    }
+  },
+  computed: {
+    // Template structure path helpers
+    templateComponents() {
+      return (
+        this.document &&
+        this.document.template &&
+        this.document.template.components
+      ) || []
+    },
+    templateContentComponents() {
+      return (
+        this.document &&
+        this.document.templateContent &&
+        this.document.templateContent.components
+      ) || []
+    },
+    headerComponent() {
+      return this.templateComponents.find(comp => comp.type === 'header')
+    },
+    headerContentComponent() {
+      return this.templateContentComponents.find(comp => comp.type === 'HEADER')
+    },
+    bodyComponent() {
+      return this.templateComponents.find(comp => comp.type === 'body')
+    },
+    bodyContentComponent() {
+      return this.templateContentComponents.find(comp => comp.type === 'BODY')
+    },
+    footerComponent() {
+      return this.templateComponents.find(comp => comp.type === 'footer')
+    },
+    footerContentComponent() {
+      return this.templateContentComponents.find(comp => comp.type === 'FOOTER')
+    },
+    buttonComponent() {
+      return this.templateComponents.find(comp => comp.type === 'button' && comp.sub_type === 'order_details')
+    },
+
+    // Header checks
+    hasTextHeader() {
+      return this.headerComponent && this.headerComponent.format === 'text'
+    },
+    hasImageHeader() {
+      return this.headerComponent && this.headerComponent.format === 'image'
+    },
+    hasDocumentHeader() {
+      return (
+        this.headerComponent &&
+        this.headerComponent.parameters &&
+        this.headerComponent.parameters[0] &&
+        this.headerComponent.parameters[0].type === 'document'
+      )
+    },
+    headerImageUrl() {
+      if (this.hasImageHeader && this.headerComponent.parameters && this.headerComponent.parameters[0]) {
+        return (this.headerComponent.parameters[0].image && this.headerComponent.parameters[0].image.link) || 'https://via.placeholder.com/40'
+      }
+      return 'https://via.placeholder.com/40'
+    },
+    documentName() {
+      if (this.hasDocumentHeader && this.headerComponent.parameters && this.headerComponent.parameters[0]) {
+        return (this.headerComponent.parameters[0].document && this.headerComponent.parameters[0].document.filename) || 'Documento'
+      }
+      return 'Documento'
+    },
+
+    // Order details from button parameters
+    orderDetails() {
+      return (
+        this.buttonComponent &&
+        this.buttonComponent.parameters &&
+        this.buttonComponent.parameters[0] &&
+        this.buttonComponent.parameters[0].action &&
+        this.buttonComponent.parameters[0].action.order_details
+      ) || {}
+    },
+    orderItems() {
+      const items = (this.orderDetails.order && this.orderDetails.order.items) || []
+      return items.length > 0 ? items : [{ name: 'Item exemplo', quantity: 1 }]
+    },
+    itemsDisplay() {
+      const items = this.orderItems
+      if (items.length === 1) {
+        const itemName = items[0].name
+        return {
+          single: true,
+          name:
+            itemName.length > 40 ? itemName.substring(0, 40) + '...' : itemName,
+          quantity: items[0].quantity
+        }
+      } else {
+        const allNames = items.map((item) => item.name).join(', ')
+        return {
+          single: false,
+          names:
+            allNames.length > 40 ? allNames.substring(0, 40) + '...' : allNames,
+          totalItems: items.length
+        }
+      }
+    },
+    orderTitle() {
+      const referenceId = this.orderDetails.reference_id || '000000'
+      return `Número da cobrança: ${referenceId}`
+    },
+    formattedTotal() {
+      const total = this.orderDetails.total_amount
+      if (total) {
+        const value = total.value / (total.offset || 100)
+        return `R$ ${value.toFixed(2).replace('.', ',')}`
+      }
+      return 'R$ 0,00'
+    },
+    paymentIcons() {
+      const settings = this.orderDetails.payment_settings || []
+      const icons = []
+
+      settings.forEach((setting) => {
+        switch (setting.type) {
+          case 'pix_dynamic_code':
+            icons.push('pix')
+            break
+          case 'boleto':
+            icons.push('barcode')
+            break
+          case 'payment_link':
+            icons.push('payment-card')
+            break
+        }
+      })
+
+      return icons.length > 0 ? icons : ['pix', 'barcode', 'payment-card']
+    },
+    paymentMethodsLabel() {
+      return 'Pagar com'
+    },
+    paymentButtons() {
+      const settings = this.orderDetails.payment_settings || []
+      const buttons = []
+
+      settings.forEach((setting) => {
+        switch (setting.type) {
+          case 'pix_dynamic_code':
+            buttons.push({
+              type: 'pix_dynamic_code',
+              text: 'Copiar Chave Pix',
+              icon: 'copy',
+              data: setting.pix_dynamic_code.code
+            })
+            break
+          case 'boleto':
+            buttons.push({
+              type: 'boleto',
+              text: 'Copiar Código do Boleto',
+              icon: 'copy',
+              data: setting.boleto.barcode
+            })
+            break
+          case 'payment_link':
+            buttons.push({
+              type: 'payment_link',
+              text: 'Abrir Link de Pagamento',
+              icon: 'external-file',
+              data: setting.payment_link.url
+            })
+            break
+        }
+      })
+
+      return buttons
+    }
+  },
+  methods: {
+    init: function() {
+      console.log('=== DEBUG TemplateOrder ===')
+      console.log('document:', this.document)
+      console.log('bodyContentComponent:', this.bodyContentComponent)
+      console.log('bodyComponent:', this.bodyComponent)
+
+      // Process header text with template parameters from templateContent
+      if (this.hasTextHeader && this.headerContentComponent) {
+        let text = this.headerContentComponent.text || ''
+
+        // Replace template placeholders with actual parameter values from template
+        if (this.headerComponent && this.headerComponent.parameters) {
+          this.headerComponent.parameters.forEach((param, index) => {
+            const placeholder = `{{${index + 1}}}`
+            if (param.type === 'text') {
+              // Escape special regex characters in placeholder
+              const escapedPlaceholder = placeholder.replace(/[{}]/g, '\\$&')
+              text = text.replace(new RegExp(escapedPlaceholder, 'g'), param.text || '')
+            }
+          })
+        }
+
+        this.headerText = text
+      }
+
+      // Process body text with template parameters from templateContent
+      if (this.bodyContentComponent) {
+        let text = this.bodyContentComponent.text || ''
+        console.log('Original body text:', text)
+
+        // Replace template placeholders with actual parameter values from template
+        if (this.bodyComponent && this.bodyComponent.parameters) {
+          console.log('Body parameters:', this.bodyComponent.parameters)
+          this.bodyComponent.parameters.forEach((param, index) => {
+            const placeholder = `{{${index + 1}}}`
+            console.log(`Replacing ${placeholder} with`, param.text)
+            if (param.type === 'text') {
+              // Escape special regex characters in placeholder
+              const escapedPlaceholder = placeholder.replace(/[{}]/g, '\\$&')
+              text = text.replace(new RegExp(escapedPlaceholder, 'g'), param.text || '')
+            }
+          })
+        }
+
+        console.log('Final body text:', text)
+        this.bodyText = text
+      }
+
+      // Process footer text from templateContent
+      if (this.footerContentComponent) {
+        this.footerText = this.footerContentComponent.text || ''
+      }
+    },
+    formatQuantity(quantity) {
+      return `Quantidade: ${quantity}`
+    },
+    formatItemsCount(count) {
+      return `${count} ${count === 1 ? 'item' : 'itens'}`
+    },
+    getIconTheme(iconName) {
+      return iconName === 'pix' ? 'solid' : 'outline'
+    },
+    handlePaymentAction(button) {
+      switch (button.type) {
+        case 'pix_dynamic_code':
+        case 'boleto':
+          this.copyToClipboard(button.data, button.text)
+          break
+        case 'payment_link':
+          window.open(button.data, '_blank', 'noopener,noreferrer')
+          break
+      }
+    },
+    copyToClipboard(text, buttonText) {
+      if (navigator.clipboard && window.isSecureContext) {
+        // Usar a API moderna do clipboard
+        navigator.clipboard
+          .writeText(text)
+          .then(() => {
+            this.showCopySuccess(buttonText)
+          })
+          .catch(() => {
+            this.fallbackCopyToClipboard(text, buttonText)
+          })
+      } else {
+        // Fallback para navegadores mais antigos
+        this.fallbackCopyToClipboard(text, buttonText)
+      }
+    },
+    fallbackCopyToClipboard(text, buttonText) {
+      const textArea = document.createElement('textarea')
+      textArea.value = text
+      textArea.style.position = 'fixed'
+      textArea.style.opacity = '0'
+      document.body.appendChild(textArea)
+      textArea.select()
+
+      try {
+        document.execCommand('copy')
+        this.showCopySuccess(buttonText)
+      } catch (err) {
+        console.error('Erro ao copiar:', err)
+      }
+
+      document.body.removeChild(textArea)
+    },
+    showCopySuccess(buttonText) {
+      // Aqui você pode adicionar uma notificação de sucesso
+      console.log(`${buttonText} copiado com sucesso!`)
+      // Exemplo: mostrar toast, alterar temporariamente o texto do botão, etc.
+    },
+    orderSave: function($event) {
+      if (this.errors.any() || ($event && $event.shiftKey)) {
+        return
+      }
+
+      this.$validator.validateAll().then((result) => {
+        if (!result) return
+
+        // For template, we would need to update the template structure
+        // This is more complex than the interactive format
+        if (this.bodyComponent) {
+          this.save({
+            ...this.bodyComponent,
+            text: this.bodyText
+          })
+        }
+
+        if (this.footerComponent) {
+          this.save({
+            ...this.footerComponent,
+            text: this.footerText
+          })
+        }
+      })
+    },
+    orderEditCancel: function() {
+      this.cancel()
+    }
+  },
+  updated: function() {
+    this.$emit('updated')
+  }
+}
+</script>
+
+<style scoped lang="scss">
+@import '../../styles/variables.scss';
+
+.template-order {
+  .divider {
+    border-top: 1px dashed $color-surface-3;
+    margin-top: 8px;
+    margin-bottom: 8px;
+    width: 100%;
+  }
+
+  .payment-button {
+    margin: 0;
+    &:not(:last-child) {
+      border-bottom: 1px solid $color-surface-3;
+      border-radius: 0;
+    }
+  }
+
+  .bubble {
+    padding: $bubble-padding;
+    padding-left: 0px;
+    padding-right: 0px;
+    min-width: 206px;
+    text-align: left;
+    max-width: 340px;
+  }
+}
+
+.mt-card__payment-block__paper-document {
+  .icon-pdf {
+    color: #d32f2f;
+  }
+}
+
+.mt-card__payment-block__paper-content {
+  background-color: $color-surface-2;
+  .image-payment {
+    border-radius: 4px;
+    object-fit: cover;
+  }
+}
+
+.color-footer-disable {
+  color: $color-content-ghost;
+}
+
+.content-color-ghost {
+  color: $color-content-ghost;
+}
+
+.blip-card .form-group .help {
+  padding: 0px;
+}
+
+.button-container {
+  width: 100%;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+.button-container-text-primary {
+  color: $color-primary;
+}
+
+.button-container-text-white {
+  color: $color-surface-1;
+}
+</style>

--- a/src/components/TemplateContent/TemplateOrder.vue
+++ b/src/components/TemplateContent/TemplateOrder.vue
@@ -23,7 +23,7 @@
         <bds-grid v-if="hasDocumentHeader" direction="column" padding="x-2">
           <bds-paper
             elevation="static"
-            class="mt-card__payment-block__paper-document"
+            class="payment-template-order__paper-document"
           >
             <bds-grid
               padding="1"
@@ -203,6 +203,7 @@
 <script>
 import { default as base } from '../../mixins/baseComponent.js'
 import { isFailedMessage } from '../../utils/misc'
+import { TemplateOrderType, TemplateOrderPaymentType, TemplateOrderIcon } from '../../enums/templateOrder.enum.js'
 
 export default {
   name: 'template-order',
@@ -230,83 +231,113 @@ export default {
     }
   },
   computed: {
-    // Template structure path helpers
     templateComponents() {
       return (
-        this.document &&
-        this.document.template &&
-        this.document.template.components
-      ) || []
+        (this.document &&
+          this.document.template &&
+          this.document.template.components) ||
+        []
+      )
     },
     templateContentComponents() {
       return (
-        this.document &&
-        this.document.templateContent &&
-        this.document.templateContent.components
-      ) || []
+        (this.document &&
+          this.document.templateContent &&
+          this.document.templateContent.components) ||
+        []
+      )
     },
     headerComponent() {
-      return this.templateComponents.find(comp => comp.type === 'header')
+      return this.templateComponents.find((comp) => comp.type === TemplateOrderType.HEADER)
     },
     headerContentComponent() {
-      return this.templateContentComponents.find(comp => comp.type === 'HEADER')
+      return this.templateContentComponents.find(
+        (comp) => comp.type === TemplateOrderType.HEADER_UPPER
+      )
     },
     bodyComponent() {
-      return this.templateComponents.find(comp => comp.type === 'body')
+      return this.templateComponents.find((comp) => comp.type === TemplateOrderType.BODY)
     },
     bodyContentComponent() {
-      return this.templateContentComponents.find(comp => comp.type === 'BODY')
+      return this.templateContentComponents.find((comp) => comp.type === TemplateOrderType.BODY_UPPER)
     },
     footerComponent() {
-      return this.templateComponents.find(comp => comp.type === 'footer')
+      return this.templateComponents.find((comp) => comp.type === TemplateOrderType.FOOTER)
     },
     footerContentComponent() {
-      return this.templateContentComponents.find(comp => comp.type === 'FOOTER')
+      return this.templateContentComponents.find(
+        (comp) => comp.type === TemplateOrderType.FOOTER_UPPER
+      )
     },
     buttonComponent() {
-      return this.templateComponents.find(comp => comp.type === 'button' && comp.sub_type === 'order_details')
+      return this.templateComponents.find(
+        (comp) => comp.type === TemplateOrderType.BUTTON && comp.sub_type === TemplateOrderType.ORDER_DETAILS
+      )
     },
 
-    // Header checks
     hasTextHeader() {
-      return this.headerComponent && this.headerComponent.format === 'text'
+      return this.headerComponent && this.headerComponent.format === TemplateOrderType.TEXT
     },
     hasImageHeader() {
-      return this.headerComponent && this.headerComponent.format === 'image'
+      return (
+        this.headerComponent &&
+        this.headerComponent.parameters &&
+        this.headerComponent.parameters[0] &&
+        this.headerComponent.parameters[0].type === TemplateOrderType.IMAGE &&
+        this.headerComponent.parameters[0].image &&
+        this.headerComponent.parameters[0].image.link
+      )
     },
     hasDocumentHeader() {
       return (
         this.headerComponent &&
         this.headerComponent.parameters &&
         this.headerComponent.parameters[0] &&
-        this.headerComponent.parameters[0].type === 'document'
+        this.headerComponent.parameters[0].type === TemplateOrderType.DOCUMENT
       )
     },
     headerImageUrl() {
-      if (this.hasImageHeader && this.headerComponent.parameters && this.headerComponent.parameters[0]) {
-        return (this.headerComponent.parameters[0].image && this.headerComponent.parameters[0].image.link) || 'https://via.placeholder.com/40'
+      if (
+        this.hasImageHeader &&
+        this.headerComponent.parameters &&
+        this.headerComponent.parameters[0]
+      ) {
+        return (
+          (this.headerComponent.parameters[0].image &&
+            this.headerComponent.parameters[0].image.link) ||
+          'https://via.placeholder.com/40'
+        )
       }
       return 'https://via.placeholder.com/40'
     },
     documentName() {
-      if (this.hasDocumentHeader && this.headerComponent.parameters && this.headerComponent.parameters[0]) {
-        return (this.headerComponent.parameters[0].document && this.headerComponent.parameters[0].document.filename) || 'Documento'
+      if (
+        this.hasDocumentHeader &&
+        this.headerComponent.parameters &&
+        this.headerComponent.parameters[0]
+      ) {
+        return (
+          (this.headerComponent.parameters[0].document &&
+            this.headerComponent.parameters[0].document.filename) ||
+          'Documento'
+        )
       }
       return 'Documento'
     },
 
-    // Order details from button parameters
     orderDetails() {
       return (
-        this.buttonComponent &&
-        this.buttonComponent.parameters &&
-        this.buttonComponent.parameters[0] &&
-        this.buttonComponent.parameters[0].action &&
-        this.buttonComponent.parameters[0].action.order_details
-      ) || {}
+        (this.buttonComponent &&
+          this.buttonComponent.parameters &&
+          this.buttonComponent.parameters[0] &&
+          this.buttonComponent.parameters[0].action &&
+          this.buttonComponent.parameters[0].action.order_details) ||
+        {}
+      )
     },
     orderItems() {
-      const items = (this.orderDetails.order && this.orderDetails.order.items) || []
+      const items =
+        (this.orderDetails.order && this.orderDetails.order.items) || []
       return items.length > 0 ? items : [{ name: 'Item exemplo', quantity: 1 }]
     },
     itemsDisplay() {
@@ -347,19 +378,19 @@ export default {
 
       settings.forEach((setting) => {
         switch (setting.type) {
-          case 'pix_dynamic_code':
-            icons.push('pix')
+          case TemplateOrderPaymentType.PIX_DYNAMIC_CODE:
+            icons.push(TemplateOrderIcon.PIX)
             break
-          case 'boleto':
-            icons.push('barcode')
+          case TemplateOrderPaymentType.BOLETO:
+            icons.push(TemplateOrderIcon.BARCODE)
             break
-          case 'payment_link':
-            icons.push('payment-card')
+          case TemplateOrderPaymentType.PAYMENT_LINK:
+            icons.push(TemplateOrderIcon.PAYMENT_CARD)
             break
         }
       })
 
-      return icons.length > 0 ? icons : ['pix', 'barcode', 'payment-card']
+      return icons.length > 0 ? icons : [TemplateOrderIcon.PIX, TemplateOrderIcon.BARCODE, TemplateOrderIcon.PAYMENT_CARD]
     },
     paymentMethodsLabel() {
       return 'Pagar com'
@@ -370,27 +401,27 @@ export default {
 
       settings.forEach((setting) => {
         switch (setting.type) {
-          case 'pix_dynamic_code':
+          case TemplateOrderPaymentType.PIX_DYNAMIC_CODE:
             buttons.push({
-              type: 'pix_dynamic_code',
+              type: TemplateOrderPaymentType.PIX_DYNAMIC_CODE,
               text: 'Copiar Chave Pix',
-              icon: 'copy',
+              icon: TemplateOrderIcon.COPY,
               data: setting.pix_dynamic_code.code
             })
             break
-          case 'boleto':
+          case TemplateOrderPaymentType.BOLETO:
             buttons.push({
-              type: 'boleto',
+              type: TemplateOrderPaymentType.BOLETO,
               text: 'Copiar Código do Boleto',
-              icon: 'copy',
+              icon: TemplateOrderIcon.COPY,
               data: setting.boleto.barcode
             })
             break
-          case 'payment_link':
+          case TemplateOrderPaymentType.PAYMENT_LINK:
             buttons.push({
-              type: 'payment_link',
+              type: TemplateOrderPaymentType.PAYMENT_LINK,
               text: 'Abrir Link de Pagamento',
-              icon: 'external-file',
+              icon: TemplateOrderIcon.EXTERNAL_FILE,
               data: setting.payment_link.url
             })
             break
@@ -402,57 +433,53 @@ export default {
   },
   methods: {
     init: function() {
-      console.log('=== DEBUG TemplateOrder ===')
-      console.log('document:', this.document)
-      console.log('bodyContentComponent:', this.bodyContentComponent)
-      console.log('bodyComponent:', this.bodyComponent)
-
-      // Process header text with template parameters from templateContent
       if (this.hasTextHeader && this.headerContentComponent) {
         let text = this.headerContentComponent.text || ''
 
-        // Replace template placeholders with actual parameter values from template
         if (this.headerComponent && this.headerComponent.parameters) {
           this.headerComponent.parameters.forEach((param, index) => {
             const placeholder = `{{${index + 1}}}`
             if (param.type === 'text') {
-              // Escape special regex characters in placeholder
               const escapedPlaceholder = placeholder.replace(/[{}]/g, '\\$&')
-              text = text.replace(new RegExp(escapedPlaceholder, 'g'), param.text || '')
+              text = text.replace(
+                new RegExp(escapedPlaceholder, 'g'),
+                param.text || ''
+              )
             }
           })
         }
 
-        this.headerText = text
+        this.headerText = this.processText(text)
       }
 
-      // Process body text with template parameters from templateContent
       if (this.bodyContentComponent) {
         let text = this.bodyContentComponent.text || ''
-        console.log('Original body text:', text)
 
-        // Replace template placeholders with actual parameter values from template
         if (this.bodyComponent && this.bodyComponent.parameters) {
-          console.log('Body parameters:', this.bodyComponent.parameters)
           this.bodyComponent.parameters.forEach((param, index) => {
             const placeholder = `{{${index + 1}}}`
-            console.log(`Replacing ${placeholder} with`, param.text)
             if (param.type === 'text') {
-              // Escape special regex characters in placeholder
               const escapedPlaceholder = placeholder.replace(/[{}]/g, '\\$&')
-              text = text.replace(new RegExp(escapedPlaceholder, 'g'), param.text || '')
+              text = text.replace(
+                new RegExp(escapedPlaceholder, 'g'),
+                param.text || ''
+              )
             }
           })
         }
 
-        console.log('Final body text:', text)
-        this.bodyText = text
+        this.bodyText = this.processText(text)
       }
 
-      // Process footer text from templateContent
       if (this.footerContentComponent) {
-        this.footerText = this.footerContentComponent.text || ''
+        this.footerText = this.processText(
+          this.footerContentComponent.text || ''
+        )
       }
+    },
+    processText: function(text) {
+      if (!text) return ''
+      return text.replace(/\\\\n/g, '\n').replace(/\\n/g, '\n')
     },
     formatQuantity(quantity) {
       return `Quantidade: ${quantity}`
@@ -476,17 +503,9 @@ export default {
     },
     copyToClipboard(text, buttonText) {
       if (navigator.clipboard && window.isSecureContext) {
-        // Usar a API moderna do clipboard
         navigator.clipboard
           .writeText(text)
-          .then(() => {
-            this.showCopySuccess(buttonText)
-          })
-          .catch(() => {
-            this.fallbackCopyToClipboard(text, buttonText)
-          })
       } else {
-        // Fallback para navegadores mais antigos
         this.fallbackCopyToClipboard(text, buttonText)
       }
     },
@@ -500,17 +519,11 @@ export default {
 
       try {
         document.execCommand('copy')
-        this.showCopySuccess(buttonText)
       } catch (err) {
         console.error('Erro ao copiar:', err)
       }
 
       document.body.removeChild(textArea)
-    },
-    showCopySuccess(buttonText) {
-      // Aqui você pode adicionar uma notificação de sucesso
-      console.log(`${buttonText} copiado com sucesso!`)
-      // Exemplo: mostrar toast, alterar temporariamente o texto do botão, etc.
     },
     orderSave: function($event) {
       if (this.errors.any() || ($event && $event.shiftKey)) {
@@ -520,8 +533,6 @@ export default {
       this.$validator.validateAll().then((result) => {
         if (!result) return
 
-        // For template, we would need to update the template structure
-        // This is more complex than the interactive format
         if (this.bodyComponent) {
           this.save({
             ...this.bodyComponent,
@@ -570,13 +581,16 @@ export default {
     padding: $bubble-padding;
     padding-left: 0px;
     padding-right: 0px;
-    min-width: 206px;
+    min-width: 210px;
     text-align: left;
-    max-width: 340px;
+    width: 290px;
+    max-width: 90%;
   }
 }
 
-.mt-card__payment-block__paper-document {
+.payment-template-order__paper-document {
+  margin-bottom: -10px !important;
+  border-radius: 6px;
   .icon-pdf {
     color: #d32f2f;
   }

--- a/src/enums/componentOrder.enum.js
+++ b/src/enums/componentOrder.enum.js
@@ -1,0 +1,24 @@
+const ComponentOrderType = Object.freeze({
+  HEADER: 'header',
+  BODY: 'body',
+  FOOTER: 'footer',
+  IMAGE: 'image',
+  DOCUMENT: 'document',
+  TEXT: 'text'
+})
+
+const ComponentOrderPaymentType = Object.freeze({
+  PIX_DYNAMIC_CODE: 'pix_dynamic_code',
+  BOLETO: 'boleto',
+  PAYMENT_LINK: 'payment_link'
+})
+
+const ComponentOrderIcon = Object.freeze({
+  PIX: 'pix',
+  BARCODE: 'barcode',
+  PAYMENT_CARD: 'payment-card',
+  COPY: 'copy',
+  EXTERNAL_FILE: 'external-file'
+})
+
+export { ComponentOrderType, ComponentOrderPaymentType, ComponentOrderIcon }

--- a/src/enums/templateOrder.enum.js
+++ b/src/enums/templateOrder.enum.js
@@ -1,0 +1,31 @@
+const TemplateOrderType = Object.freeze({
+  HEADER: 'header',
+  BODY: 'body',
+  FOOTER: 'footer',
+  BUTTON: 'button',
+  ORDER_DETAILS: 'order_details',
+  IMAGE: 'image',
+  DOCUMENT: 'document',
+  TEXT: 'text',
+  BUTTONS: 'BUTTONS',
+  BODY_UPPER: 'BODY',
+  HEADER_UPPER: 'HEADER',
+  FOOTER_UPPER: 'FOOTER',
+  ORDER_DETAILS_UPPER: 'ORDER_DETAILS'
+})
+
+const TemplateOrderPaymentType = Object.freeze({
+  PIX_DYNAMIC_CODE: 'pix_dynamic_code',
+  BOLETO: 'boleto',
+  PAYMENT_LINK: 'payment_link'
+})
+
+const TemplateOrderIcon = Object.freeze({
+  PIX: 'pix',
+  BARCODE: 'barcode',
+  PAYMENT_CARD: 'payment-card',
+  COPY: 'copy',
+  EXTERNAL_FILE: 'external-file'
+})
+
+export { TemplateOrderType, TemplateOrderPaymentType, TemplateOrderIcon }

--- a/src/index.js
+++ b/src/index.js
@@ -86,6 +86,7 @@ import PhoneNumberButton from './components/TemplateContent/Buttons/PhoneNumberB
 import WebsiteButton from './components/TemplateContent/Buttons/WebsiteButton'
 import MediaContent from './components/TemplateContent/MediaContent/MediaContent'
 import TemplateContent from './components/TemplateContent/TemplateContent'
+import TemplateOrder from './components/TemplateContent/TemplateOrder'
 
 function install(Vue) {
   let components = []
@@ -155,6 +156,7 @@ function install(Vue) {
 
   // TemplateContent components
   components.push(Vue.component(TemplateContent.name, TemplateContent))
+  components.push(Vue.component(TemplateOrder.name, TemplateOrder))
   components.push(Vue.component(WebsiteButton.name, WebsiteButton))
   components.push(Vue.component(PhoneNumberButton.name, PhoneNumberButton))
   components.push(Vue.component(MediaContent.name, MediaContent))
@@ -206,6 +208,7 @@ export default {
   Location,
   RequestLocation,
   TemplateContent,
+  TemplateOrder,
   UnsuportedContent,
   BlipExternal,
   install


### PR DESCRIPTION
This pull request introduces support for rendering "order details" components in both interactive messages and template messages. It achieves this by adding new components, enums, and logic to detect and display order details appropriately. The changes are grouped into two main themes: feature implementation and supporting infrastructure.

**Feature Implementation**

* Added a new `ComponentOrder` component to render interactive messages with `order_details` type, and integrated it into `ApplicationJSon.vue` for proper display. [[1]](diffhunk://#diff-f91885a2d441bc5335529ff3eb3bfc0dc4f74e0d799c9d1004c0c92f2e3768edR84-R92) [[2]](diffhunk://#diff-f91885a2d441bc5335529ff3eb3bfc0dc4f74e0d799c9d1004c0c92f2e3768edR148) [[3]](diffhunk://#diff-f91885a2d441bc5335529ff3eb3bfc0dc4f74e0d799c9d1004c0c92f2e3768edL181-R192)
* Introduced the `TemplateOrder` component for rendering template messages that contain order details, including logic in `BlipCard.vue` to detect and display these templates only when relevant. [[1]](diffhunk://#diff-4ce687a4c4ec047d40ef6ac305a5caef6420016b693a5e41a988c3a47c9b698fR429-R439) [[2]](diffhunk://#diff-4ce687a4c4ec047d40ef6ac305a5caef6420016b693a5e41a988c3a47c9b698fR726) [[3]](diffhunk://#diff-4ce687a4c4ec047d40ef6ac305a5caef6420016b693a5e41a988c3a47c9b698fR902-R914) [[4]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R89) [[5]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R159) [[6]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R211)

**Supporting Infrastructure**

* Created new enums in `componentOrder.enum.js` and `templateOrder.enum.js` to standardize order-related types, payment types, and icons for use in the new components. [[1]](diffhunk://#diff-c5a98c05d93cb689cbf8bd558505b3a51c0d2955529b0ba7c9b2bb8181f75930R1-R24) [[2]](diffhunk://#diff-750833c315fa4e7b9befebd8c8ef44ab6d6e182b43ba45b7ad3150bba3224c08R1-R31)