### PR TITLE
fix: add class to card for right position 954934 

### DIFF
--- a/src/components/ApplicationJSon/ComponentOrder.vue
+++ b/src/components/ApplicationJSon/ComponentOrder.vue
@@ -24,6 +24,8 @@
           <bds-paper
             elevation="static"
             class="payment-component-order__paper-document"
+            @click="handleDocumentDownload"
+            style="cursor: pointer;"
           >
             <bds-grid
               padding="1"
@@ -260,13 +262,22 @@ export default {
       )
     },
     documentName() {
+      const filename =
+        this.document &&
+        this.document.interactive &&
+        this.document.interactive.header &&
+        this.document.interactive.header.document &&
+        this.document.interactive.header.document.filename
+      return filename || 'documento.pdf'
+    },
+    documentLink() {
       return (
         (this.document &&
           this.document.interactive &&
           this.document.interactive.header &&
           this.document.interactive.header.document &&
-          this.document.interactive.header.document.filename) ||
-        'Documento'
+          this.document.interactive.header.document.link) ||
+        ''
       )
     },
     orderItems() {
@@ -454,6 +465,11 @@ export default {
         case 'payment_link':
           window.open(button.data, '_blank', 'noopener,noreferrer')
           break
+      }
+    },
+    handleDocumentDownload() {
+      if (this.documentLink) {
+        window.open(this.documentLink, '_blank', 'noopener,noreferrer')
       }
     },
     copyToClipboard(text, buttonText) {

--- a/src/components/ApplicationJSon/ComponentOrder.vue
+++ b/src/components/ApplicationJSon/ComponentOrder.vue
@@ -140,11 +140,11 @@
             justify-content="space-between"
             align-items="center"
           >
-            <bds-typo variant="fs-14" bold="bold">{{ headerText }}</bds-typo>
+            <bds-typo class="typo" variant="fs-14" bold="bold">{{ headerText }}</bds-typo>
           </bds-grid>
 
           <bds-grid justify-content="space-between" align-items="center">
-            <bds-typo variant="fs-14" style="white-space: pre-line;">{{
+            <bds-typo class="typo" variant="fs-14" style="white-space: pre-line;">{{
               bodyText
             }}</bds-typo>
           </bds-grid>
@@ -154,7 +154,7 @@
             justify-content="space-between"
             align-items="center"
           >
-            <bds-typo variant="fs-12" class="color-footer-disable">{{
+            <bds-typo class="typo" variant="fs-12">{{
               footerText
             }}</bds-typo>
           </bds-grid>

--- a/src/components/TemplateContent/TemplateOrder.vue
+++ b/src/components/TemplateContent/TemplateOrder.vue
@@ -24,6 +24,8 @@
           <bds-paper
             elevation="static"
             class="payment-template-order__paper-document"
+            @click="handleDocumentDownload"
+            style="cursor: pointer;"
           >
             <bds-grid
               padding="1"
@@ -316,13 +318,26 @@ export default {
         this.headerComponent.parameters &&
         this.headerComponent.parameters[0]
       ) {
+        const filename =
+          this.headerComponent.parameters[0].document &&
+          this.headerComponent.parameters[0].document.filename
+        return filename || 'documento.pdf'
+      }
+      return 'documento.pdf'
+    },
+    documentLink() {
+      if (
+        this.hasDocumentHeader &&
+        this.headerComponent.parameters &&
+        this.headerComponent.parameters[0]
+      ) {
         return (
           (this.headerComponent.parameters[0].document &&
-            this.headerComponent.parameters[0].document.filename) ||
-          'Documento'
+            this.headerComponent.parameters[0].document.link) ||
+          ''
         )
       }
-      return 'Documento'
+      return ''
     },
 
     orderDetails() {
@@ -499,6 +514,11 @@ export default {
         case 'payment_link':
           window.open(button.data, '_blank', 'noopener,noreferrer')
           break
+      }
+    },
+    handleDocumentDownload() {
+      if (this.documentLink) {
+        window.open(this.documentLink, '_blank', 'noopener,noreferrer')
       }
     },
     copyToClipboard(text, buttonText) {

--- a/src/components/TemplateContent/TemplateOrder.vue
+++ b/src/components/TemplateContent/TemplateOrder.vue
@@ -144,12 +144,12 @@
             justify-content="space-between"
             align-items="center"
           >
-            <bds-typo variant="fs-14" bold="bold">{{ headerText }}</bds-typo>
+            <bds-typo class="typo" variant="fs-14" bold="bold">{{ headerText }}</bds-typo>
           </bds-grid>
 
           <!-- Body Text -->
           <bds-grid justify-content="space-between" align-items="center">
-            <bds-typo variant="fs-14" style="white-space: pre-line;">{{
+            <bds-typo class="typo" variant="fs-14" style="white-space: pre-line;">{{
               bodyText
             }}</bds-typo>
           </bds-grid>
@@ -160,7 +160,7 @@
             justify-content="space-between"
             align-items="center"
           >
-            <bds-typo variant="fs-12" class="color-footer-disable">{{
+            <bds-typo variant="fs-12" class="typo">{{
               footerText
             }}</bds-typo>
           </bds-grid>


### PR DESCRIPTION
This pull request introduces improvements to the ComponentOrder.vue and TemplateOrder.vue components, primarily to enhance the document download experience and standardize the UI styling. The main changes include adding a clickable document download feature, refactoring computed properties for the document name and link.

It also includes a typography adjustment to ensure proper rendering when the card is displayed on the right side of the conversation. In this case, the component changes its background color, and previously the text was inheriting the body color, resulting in the text matching the background. The update ensures proper contrast and correct rendering in both display contexts.

**Document Download Functionality**
* Added a new `handleDocumentDownload` method and bound it to the document paper's click event, allowing users to download or view documents in a new tab. [[1]](diffhunk://#diff-3ab15dd5d4b4c66c42eb9d374bf69320785a19894ce76f3edba252fad64b1c80R27-R28) [[2]](diffhunk://#diff-3ab15dd5d4b4c66c42eb9d374bf69320785a19894ce76f3edba252fad64b1c80R470-R474) [[3]](diffhunk://#diff-4e56f05b44fa2c3d06f11444df304f65ca05d00661ad4e800afca2600a3867fdR27-R28) [[4]](diffhunk://#diff-4e56f05b44fa2c3d06f11444df304f65ca05d00661ad4e800afca2600a3867fdR519-R523)

**Computed Properties Refactor**
* Refactored `documentName` and `documentLink` computed properties in both components to correctly extract the filename and link, providing better fallback values and ensuring more robust data handling. [[1]](diffhunk://#diff-3ab15dd5d4b4c66c42eb9d374bf69320785a19894ce76f3edba252fad64b1c80R265-R280) [[2]](diffhunk://#diff-4e56f05b44fa2c3d06f11444df304f65ca05d00661ad4e800afca2600a3867fdR316-R340)

**UI Consistency**
* Updated all `bds-typo` elements to include a shared `typo` class, ensuring consistent typography styling across headers, body, and footers. [[1]](diffhunk://#diff-3ab15dd5d4b4c66c42eb9d374bf69320785a19894ce76f3edba252fad64b1c80L143-R149) [[2]](diffhunk://#diff-3ab15dd5d4b4c66c42eb9d374bf69320785a19894ce76f3edba252fad64b1c80L157-R159) [[3]](diffhunk://#diff-4e56f05b44fa2c3d06f11444df304f65ca05d00661ad4e800afca2600a3867fdL147-R154) [[4]](diffhunk://#diff-4e56f05b44fa2c3d06f11444df304f65ca05d00661ad4e800afca2600a3867fdL163-R165)